### PR TITLE
Disable file caching on openshift

### DIFF
--- a/adoptopenjdk-api-v3-frontend/src/main/resources/application.properties
+++ b/adoptopenjdk-api-v3-frontend/src/main/resources/application.properties
@@ -8,3 +8,5 @@ quarkus.http.test-port=8080
 
 quarkus.log.console.enable=true
 quarkus.log.file.enable=true
+
+vertx.disableFileCPResolving=true


### PR DESCRIPTION
Vertx on Openshift is throwing exceptions, see (https://github.com/eclipse-vertx/vert.x/issues/1931). Trying to disable cache as a fix.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `mvn clean package` build and test completes
- [ ] documentation is changed or added