### PR TITLE
Default the project type to jdk when none is provided

### DIFF
--- a/adoptopenjdk-api-v3-frontend/src/main/kotlin/net/adoptopenjdk/api/v3/routes/AssetsResource.kt
+++ b/adoptopenjdk-api-v3-frontend/src/main/kotlin/net/adoptopenjdk/api/v3/routes/AssetsResource.kt
@@ -83,7 +83,7 @@ class AssetsResource {
             @QueryParam("vendor")
             vendor: Vendor?,
 
-            @Parameter(name = "project", description = "Project", required = false)
+            @Parameter(name = "project", description = "Project", schema = Schema(defaultValue = "jdk", enumeration = ["jdk", "valhalla", "metropolis", "jfr"], required = false), required = false)
             @QueryParam("project")
             project: Project?,
 
@@ -155,7 +155,7 @@ class AssetsResource {
             @QueryParam("vendor")
             vendor: Vendor?,
 
-            @Parameter(name = "project", description = "Project", required = false)
+            @Parameter(name = "project", description = "Project", schema = Schema(defaultValue = "jdk", enumeration = ["jdk", "valhalla", "metropolis", "jfr"], required = false), required = false)
             @QueryParam("project")
             project: Project?,
 

--- a/adoptopenjdk-api-v3-frontend/src/main/kotlin/net/adoptopenjdk/api/v3/routes/BinaryResource.kt
+++ b/adoptopenjdk-api-v3-frontend/src/main/kotlin/net/adoptopenjdk/api/v3/routes/BinaryResource.kt
@@ -78,11 +78,10 @@ class BinaryResource {
             @PathParam("vendor")
             vendor: Vendor?,
 
-            @Parameter(name = "project", description = "Project", required = false)
+            @Parameter(name = "project", description = "Project", schema = Schema(defaultValue = "jdk", enumeration = ["jdk", "valhalla", "metropolis", "jfr"], required = false), required = false)
             @QueryParam("project")
             project: Project?
     ): Response {
-
         val releaseFilter = ReleaseFilter(null, null, release_name, vendor, null)
         val binaryFilter = BinaryFilter(os, arch, image_type, jvm_impl, heap_size, project)
         val releases = APIDataStore.getAdoptRepos().getFilteredReleases(releaseFilter, binaryFilter, SortOrder.DESC).toList()
@@ -135,7 +134,7 @@ class BinaryResource {
             @PathParam("vendor")
             vendor: Vendor?,
 
-            @Parameter(name = "project", description = "Project", required = false)
+            @Parameter(name = "project", description = "Project", schema = Schema(defaultValue = "jdk", enumeration = ["jdk", "valhalla", "metropolis", "jfr"], required = false), required = false)
             @QueryParam("project")
             project: Project?
     ): Response {

--- a/adoptopenjdk-api-v3-frontend/src/test/kotlin/net/adoptopenjdk/api/BinaryPathTest.kt
+++ b/adoptopenjdk-api-v3-frontend/src/test/kotlin/net/adoptopenjdk/api/BinaryPathTest.kt
@@ -7,7 +7,13 @@ import kotlinx.coroutines.runBlocking
 import net.adoptopenjdk.api.v3.AdoptReposBuilder
 import net.adoptopenjdk.api.v3.dataSources.APIDataStore
 import net.adoptopenjdk.api.v3.dataSources.ApiPersistenceFactory
-import net.adoptopenjdk.api.v3.models.*
+import net.adoptopenjdk.api.v3.models.Architecture
+import net.adoptopenjdk.api.v3.models.HeapSize
+import net.adoptopenjdk.api.v3.models.ImageType
+import net.adoptopenjdk.api.v3.models.JvmImpl
+import net.adoptopenjdk.api.v3.models.OperatingSystem
+import net.adoptopenjdk.api.v3.models.ReleaseType
+import net.adoptopenjdk.api.v3.models.Vendor
 import org.hamcrest.Matchers
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test

--- a/adoptopenjdk-api-v3-models/src/main/kotlin/net/adoptopenjdk/api/v3/dataSources/filters/BinaryFilter.kt
+++ b/adoptopenjdk-api-v3-models/src/main/kotlin/net/adoptopenjdk/api/v3/dataSources/filters/BinaryFilter.kt
@@ -1,16 +1,38 @@
 package net.adoptopenjdk.api.v3.dataSources.filters
 
-import net.adoptopenjdk.api.v3.models.*
+import net.adoptopenjdk.api.v3.models.Architecture
+import net.adoptopenjdk.api.v3.models.Binary
+import net.adoptopenjdk.api.v3.models.HeapSize
+import net.adoptopenjdk.api.v3.models.ImageType
+import net.adoptopenjdk.api.v3.models.JvmImpl
+import net.adoptopenjdk.api.v3.models.OperatingSystem
+import net.adoptopenjdk.api.v3.models.Project
 import java.util.function.Predicate
 
-class BinaryFilter(
-        private val os: OperatingSystem?,
-        private val arch: Architecture?,
-        private val imageType: ImageType?,
-        private val jvmImpl: JvmImpl?,
-        private val heapSize: HeapSize?,
-        private val project: Project?
-) : Predicate<Binary> {
+class BinaryFilter : Predicate<Binary> {
+
+    private val os: OperatingSystem?
+    private val arch: Architecture?
+    private val imageType: ImageType?
+    private val jvmImpl: JvmImpl?
+    private val heapSize: HeapSize?
+    private val project: Project
+
+    constructor(
+            os: OperatingSystem?,
+            arch: Architecture?,
+            imageType: ImageType?,
+            jvmImpl: JvmImpl?,
+            heapSize: HeapSize?,
+            project: Project?
+    ) {
+        this.os = os
+        this.arch = arch
+        this.imageType = imageType
+        this.jvmImpl = jvmImpl
+        this.heapSize = heapSize
+        this.project = project ?: Project.jdk
+    }
 
     override fun test(binary: Binary): Boolean {
         return (os == null || binary.os == os) &&
@@ -18,7 +40,7 @@ class BinaryFilter(
                 (imageType == null || binary.image_type == imageType) &&
                 (jvmImpl == null || binary.jvm_impl == jvmImpl) &&
                 (heapSize == null || binary.heap_size == heapSize) &&
-                (project == null || binary.project == project)
+                (binary.project == project)
     }
 
 }

--- a/adoptopenjdk-api-v3-models/src/main/kotlin/net/adoptopenjdk/api/v3/models/Binary.kt
+++ b/adoptopenjdk-api-v3-models/src/main/kotlin/net/adoptopenjdk/api/v3/models/Binary.kt
@@ -35,7 +35,7 @@ class Binary {
     @Schema(example = "dd28d6d2cde2b931caf94ac2422a2ad082ea62f0beee3bf7057317c53093de93")
     val scm_ref: String?
 
-    @Schema(example = "jdk")
+    @Schema(example = "jdk", defaultValue = "jdk")
     val project: Project
 
     constructor(

--- a/adoptopenjdk-api-v3-models/src/main/kotlin/net/adoptopenjdk/api/v3/models/Project.kt
+++ b/adoptopenjdk-api-v3-models/src/main/kotlin/net/adoptopenjdk/api/v3/models/Project.kt
@@ -3,6 +3,8 @@ package net.adoptopenjdk.api.v3.models
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType
 import org.eclipse.microprofile.openapi.annotations.media.Schema
 
+//If you are adding to this class, due to limitiations on annotations the enumeration arg on this annotation is duplicated
+//in a number of locations, unfortunately you must go update them all
 @Schema(type = SchemaType.STRING, defaultValue = "jdk", enumeration = ["jdk", "valhalla", "metropolis", "jfr"], example = "jdk")
 enum class Project : FileNameMatcher {
     jdk,


### PR DESCRIPTION
This should fix #112. I believe the presence of both jdk and jfr binaries inside the release meant that the api was unable to determine which binary to return.

Fixed by defaulting to the jdk project type when none is provided.

This will have the consequence of meaning that jfr builds will not be returned by default to the website and if we want them on the website will have to be retrieved via a separate call, @gdams may want to confirm that is ok.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `mvn clean package` build and test completes
- [ ] documentation is changed or added