### PR TITLE
When grouping releases, ignore optional values

### DIFF
--- a/adoptopenjdk-api-v3-updater/src/main/kotlin/net/adoptopenjdk/api/v3/mapping/adopt/AdoptReleaseMapper.kt
+++ b/adoptopenjdk-api-v3-updater/src/main/kotlin/net/adoptopenjdk/api/v3/mapping/adopt/AdoptReleaseMapper.kt
@@ -40,12 +40,17 @@ object AdoptReleaseMapper : ReleaseMapper() {
         try {
             val groupedByVersion = metadata
                     .entries
-                    .groupBy { it.value.version }
+                    .groupBy {
+                        val version = it.value.version
+                        "${version.major}.${version.minor}.${version.security}.${version.build}.${version.adopt_build_number}"
+                    }
 
             return groupedByVersion
                     .entries
                     .map { grouped ->
-                        val version = grouped.key.toApiVersion()
+                        val version = grouped.value.sortedBy { it.value.version.toApiVersion() }
+                                .last().value.version.toApiVersion()
+
                         val assets = grouped.value.map { it.key }
                         val id = generateIdForSplitRelease(version, release)
 

--- a/adoptopenjdk-api-v3-updater/src/test/kotlin/net/adoptopenjdk/api/AdoptReleaseMapperTest.kt
+++ b/adoptopenjdk-api-v3-updater/src/test/kotlin/net/adoptopenjdk/api/AdoptReleaseMapperTest.kt
@@ -19,6 +19,7 @@ import org.apache.http.ProtocolVersion
 import org.apache.http.message.BasicHeader
 import org.apache.http.message.BasicStatusLine
 import org.junit.jupiter.api.Test
+import java.util.*
 import kotlin.test.assertEquals
 import kotlin.test.fail
 
@@ -136,6 +137,7 @@ class AdoptReleaseMapperTest : BaseTest() {
                 }
 
                 fun getMetadata(url: String): String {
+                    val opt = UUID.randomUUID()
                     return """
                         {
                             "WARNING": "THIS METADATA FILE IS STILL IN ALPHA DO NOT USE ME",
@@ -148,10 +150,10 @@ class AdoptReleaseMapperTest : BaseTest() {
                                 "pre": null,
                                 "adopt_build_number": 1,
                                 "major": 8,
-                                "version": "1.8.0_242-202001081700-b0${url}",
-                                "semver": "8.0.242+${url}.1.202001081700",
+                                "version": "1.8.0_242-${opt}-b0${url}",
+                                "semver": "8.0.242+${url}.1.${opt}",
                                 "build": ${url},
-                                "opt": "202001081700"
+                                "opt": "${opt}"
                             },
                             "scmRef": "",
                             "version_data": "jdk8u",


### PR DESCRIPTION
Ignore optional parts of the version string when splitting releases to avoid over splitting nightlies

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `mvn clean package` build and test completes
- [ ] documentation is changed or added