### PR TITLE
add test for aarch ea version string

### DIFF
--- a/adoptopenjdk-api-v3-models/src/test/kotlin/net/adoptopenjdk/api/VersionParserTest.kt
+++ b/adoptopenjdk-api-v3-models/src/test/kotlin/net/adoptopenjdk/api/VersionParserTest.kt
@@ -98,7 +98,12 @@ class VersionParserTest {
                             VersionData(13, 0, 0, "", null, 0, "2019-10-30-23-10", "13u-2019-10-30-23-10"),
                             "13.0.0+2019-10-30-23-10"
                     )
-            )
+            ),
+            Pair("jdk-11.0.7-ea+9_openj9-0.20.0",
+                    VersionTestData(
+                            VersionData(11, 0, 7, "ea", null, 9, null, "11.0.7-ea+9"),
+                            "11.0.7-ea+9"
+                    ))
     )
 
     @TestFactory


### PR DESCRIPTION
When parsing `jdk-11.0.7-ea+9_openj9-0.20.0` version produced looks as follows:

```
{
   "adopt_build_number" : null,
   "build" : 9,
   "major" : 11,
   "minor" : 0,
   "openjdk_version" : "11.0.7-ea+9",
   "optional" : null,
   "pre" : "ea",
   "security" : 7,
   "semver" : "11.0.7-ea+9"
}

```


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `mvn clean package` build and test completes
- [ ] documentation is changed or added