### PR TITLE
New monthly endpoint and adding jvmImpl filter

### DIFF
--- a/adoptopenjdk-api-v3-frontend/src/test/kotlin/net/adoptopenjdk/api/DownloadStatsPathTest.kt
+++ b/adoptopenjdk-api-v3-frontend/src/test/kotlin/net/adoptopenjdk/api/DownloadStatsPathTest.kt
@@ -45,22 +45,28 @@ class DownloadStatsPathTest : BaseTest() {
         private fun createGithubData(): List<GithubDownloadStatsDbEntry> {
             return listOf(
                     GithubDownloadStatsDbEntry(
+                            TimeSource.now().minusDays(15),
+                            0,
+                            null,
+                            11
+                    ),
+                    GithubDownloadStatsDbEntry(
                             TimeSource.now().minusDays(10),
                             10,
                             mapOf(JvmImpl.hotspot to 10L),
-                            8
+                            11
                     ),
                     GithubDownloadStatsDbEntry(
                             TimeSource.now().minusDays(5),
                             20,
                             mapOf(JvmImpl.hotspot to 16L, JvmImpl.openj9 to 4L),
-                            9
+                            8
                     ),
                     GithubDownloadStatsDbEntry(
                             TimeSource.now().minusDays(1),
                             40,
                             mapOf(JvmImpl.hotspot to 30L, JvmImpl.openj9 to 10L),
-                            9
+                            11
                     ),
                     GithubDownloadStatsDbEntry(
                             TimeSource.now().minusDays(1).minusMinutes(1),
@@ -80,38 +86,45 @@ class DownloadStatsPathTest : BaseTest() {
         private fun createDockerStatsWithRepoName(): List<DockerDownloadStatsDbEntry> {
             return listOf(
                     DockerDownloadStatsDbEntry(
+                            TimeSource.now().minusDays(15),
+                            0,
+                            "b-repo-name",
+                            null,
+                            null
+                    ),
+                    DockerDownloadStatsDbEntry(
                             TimeSource.now().minusDays(10),
                             20,
                             "a-repo-name",
-                            8,
-                            JvmImpl.hotspot
+                            11,
+                            JvmImpl.openj9
                     ),
                     DockerDownloadStatsDbEntry(
                             TimeSource.now().minusDays(5),
                             30,
                             "b-repo-name",
-                            11,
-                            JvmImpl.openj9
+                            8,
+                            JvmImpl.hotspot
                     ),
                     DockerDownloadStatsDbEntry(
                             TimeSource.now().minusDays(1),
                             40,
                             "b-repo-name",
-                            14,
+                            11,
                             JvmImpl.hotspot
                     ),
                     DockerDownloadStatsDbEntry(
                             TimeSource.now().minusDays(1).minusMinutes(1),
                             50,
                             "a-repo-name",
-                            10,
-                            JvmImpl.hotspot
+                            8,
+                            JvmImpl.openj9
                     ),
                     DockerDownloadStatsDbEntry(
                             TimeSource.now().minusDays(1),
                             60,
                             "a-repo-name",
-                            13,
+                            8,
                             JvmImpl.openj9
                     )
             )
@@ -137,7 +150,7 @@ class DownloadStatsPathTest : BaseTest() {
                                     stats.total_downloads.docker_pulls == 100L &&
                                     stats.total_downloads.github_downloads == 70L &&
                                     stats.github_downloads[8] == 30L &&
-                                    stats.github_downloads[9] == 40L &&
+                                    stats.github_downloads[11] == 40L &&
                                     stats.docker_pulls["a-repo-name"] == 60L &&
                                     stats.docker_pulls["b-repo-name"] == 40L
                         }
@@ -224,9 +237,86 @@ class DownloadStatsPathTest : BaseTest() {
 
                         override fun matchesSafely(p0: String?): Boolean {
                             val stats = JsonMapper.mapper.readValue(p0, List::class.java)
-                            return stats.isNotEmpty() &&
-                                    (stats[1] as Map<String, *>).get("total") == 170 &&
-                                    (stats[1] as Map<String, *>).get("daily") == 30
+                            return stats.size == 3 &&
+                                    (stats[0] as Map<String, *>).get("total") == 30 &&
+                                    (stats[0] as Map<String, *>).get("daily") == 6 &&
+                                    (stats[1] as Map<String, *>).get("total") == 50 &&
+                                    (stats[1] as Map<String, *>).get("daily") == 4 &&
+                                    (stats[2] as Map<String, *>).get("total") == 170 &&
+                                    (stats[2] as Map<String, *>).get("daily") == 30
+                        }
+                    })
+        }
+    }
+
+    @Test
+    fun trackingFeatureVersionRetrunsSaneData() {
+        runBlocking {
+            RestAssured.given()
+                    .`when`()
+                    .get("/v3/stats/downloads/tracking?feature_version=11")
+                    .then()
+                    .body(object : TypeSafeMatcher<String>() {
+
+                        override fun describeTo(description: Description?) {
+                            description!!.appendText("json")
+                        }
+
+                        override fun matchesSafely(p0: String?): Boolean {
+                            val stats = JsonMapper.mapper.readValue(p0, List::class.java)
+                            return stats.size == 2 &&
+                                    (stats[0] as Map<String, *>).get("total") == 30 &&
+                                    (stats[0] as Map<String, *>).get("daily") == 6 &&
+                                    (stats[1] as Map<String, *>).get("total") == 80 &&
+                                    (stats[1] as Map<String, *>).get("daily") == 5
+                        }
+                    })
+        }
+    }
+
+    @Test
+    fun trackingJvmImplRetrunsSaneData() {
+        runBlocking {
+            RestAssured.given()
+                    .`when`()
+                    .get("/v3/stats/downloads/tracking?jvm_impl=hotspot")
+                    .then()
+                    .body(object : TypeSafeMatcher<String>() {
+
+                        override fun describeTo(description: Description?) {
+                            description!!.appendText("json")
+                        }
+
+                        override fun matchesSafely(p0: String?): Boolean {
+                            val stats = JsonMapper.mapper.readValue(p0, List::class.java)
+                            return stats.size == 2 &&
+                                    (stats[0] as Map<String, *>).get("total") == 46 &&
+                                    (stats[0] as Map<String, *>).get("daily") == 7 &&
+                                    (stats[1] as Map<String, *>).get("total") == 90 &&
+                                    (stats[1] as Map<String, *>).get("daily") == 11
+                        }
+                    })
+        }
+    }
+
+    @Test
+    fun trackingDockerRepoRetrunsSaneData() {
+        runBlocking {
+            RestAssured.given()
+                    .`when`()
+                    .get("/v3/stats/downloads/tracking?source=dockerhub&docker_repo=a-repo-name")
+                    .then()
+                    .body(object : TypeSafeMatcher<String>() {
+
+                        override fun describeTo(description: Description?) {
+                            description!!.appendText("json")
+                        }
+
+                        override fun matchesSafely(p0: String?): Boolean {
+                            val stats = JsonMapper.mapper.readValue(p0, List::class.java)
+                            return stats.size == 1 &&
+                                    (stats[0] as Map<String, *>).get("total") == 60 &&
+                                    (stats[0] as Map<String, *>).get("daily") == 4
                         }
                     })
         }
@@ -249,12 +339,14 @@ class DownloadStatsPathTest : BaseTest() {
     fun dateRangeFilterWithEndIsCorrect() {
         requestStats(
                 null,
-                TimeSource.date().format(DateTimeFormatter.ISO_DATE),
+                TimeSource.date().minusDays(2).format(DateTimeFormatter.ISO_DATE),
                 null,
                 { stats ->
                     stats.size == 2 &&
-                            (stats[0] as Map<String, *>).get("total") == 50 &&
-                            (stats[0] as Map<String, *>).get("daily") == 4
+                            (stats[0] as Map<String, *>).get("total") == 30 &&
+                            (stats[0] as Map<String, *>).get("daily") == 6 &&
+                            (stats[1] as Map<String, *>).get("total") == 50 &&
+                            (stats[1] as Map<String, *>).get("daily") == 4
                 })
     }
 

--- a/adoptopenjdk-api-v3-frontend/src/test/kotlin/net/adoptopenjdk/api/MonthlyStatsPathTest.kt
+++ b/adoptopenjdk-api-v3-frontend/src/test/kotlin/net/adoptopenjdk/api/MonthlyStatsPathTest.kt
@@ -1,0 +1,244 @@
+package net.adoptopenjdk.api
+
+import io.quarkus.test.junit.QuarkusTest
+import io.restassured.RestAssured
+import kotlinx.coroutines.runBlocking
+import net.adoptopenjdk.api.v3.JsonMapper
+import net.adoptopenjdk.api.v3.TimeSource
+import net.adoptopenjdk.api.v3.dataSources.ApiPersistenceFactory
+import net.adoptopenjdk.api.v3.models.DockerDownloadStatsDbEntry
+import net.adoptopenjdk.api.v3.models.GithubDownloadStatsDbEntry
+import net.adoptopenjdk.api.v3.models.JvmImpl
+import org.hamcrest.Description
+import org.hamcrest.TypeSafeMatcher
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+
+@QuarkusTest
+class MonthlyStatsPathTest : BaseTest() {
+    companion object {
+        @JvmStatic
+        @BeforeAll
+        fun before() {
+            populateDb()
+            mockStats()
+        }
+
+        fun mockStats() {
+            runBlocking {
+                val persistance = ApiPersistenceFactory.get()
+
+                persistance.addDockerDownloadStatsEntries(
+                        createDockerStatsWithRepoName()
+                )
+
+                persistance.addGithubDownloadStatsEntries(
+                        createGithubData()
+                )
+            }
+        }
+
+        private fun createGithubData(): List<GithubDownloadStatsDbEntry> {
+            return listOf(
+                    GithubDownloadStatsDbEntry(
+                            TimeSource.now(),
+                            800,
+                            mapOf(JvmImpl.hotspot to 600L, JvmImpl.openj9 to 200L),
+                            11
+                    ),
+                    GithubDownloadStatsDbEntry(
+                            TimeSource.now().minusMonths(1).withDayOfMonth(26),
+                            600,
+                            mapOf(JvmImpl.hotspot to 450L, JvmImpl.openj9 to 150L),
+                            8
+                    ),
+                    GithubDownloadStatsDbEntry(
+                            TimeSource.now().minusMonths(1).withDayOfMonth(4),
+                            400,
+                            mapOf(JvmImpl.hotspot to 300L, JvmImpl.openj9 to 100L),
+                            11
+                    ),
+                    GithubDownloadStatsDbEntry(
+                            TimeSource.now().minusMonths(2).withDayOfMonth(23),
+                            350,
+                            mapOf(JvmImpl.hotspot to 275L, JvmImpl.openj9 to 75L),
+                            11
+                    ),
+                    GithubDownloadStatsDbEntry(
+                            TimeSource.now().minusMonths(3).withDayOfMonth(24),
+                            200,
+                            mapOf(JvmImpl.hotspot to 150L, JvmImpl.openj9 to 50L),
+                            8
+                    ),
+                    GithubDownloadStatsDbEntry(
+                            TimeSource.now().minusMonths(4).withDayOfMonth(19),
+                            100,
+                            null,
+                            8
+                    ),
+                    GithubDownloadStatsDbEntry(
+                            TimeSource.now().minusMonths(4).withDayOfMonth(19),
+                            100,
+                            null,
+                            11
+                    )
+            )
+        }
+
+        private fun createDockerStatsWithRepoName(): List<DockerDownloadStatsDbEntry> {
+            return listOf(
+                    DockerDownloadStatsDbEntry(
+                            TimeSource.now(),
+                            600,
+                            "a-repo-name",
+                            8,
+                            JvmImpl.hotspot
+                    ),
+                    DockerDownloadStatsDbEntry(
+                            TimeSource.now().minusMonths(1).withDayOfMonth(26),
+                            500,
+                            "b-repo-name",
+                            8,
+                            JvmImpl.openj9
+                    ),
+                    DockerDownloadStatsDbEntry(
+                            TimeSource.now().minusMonths(1).withDayOfMonth(4),
+                            310,
+                            "a-repo-name",
+                            11,
+                            JvmImpl.openj9
+                    ),
+                    DockerDownloadStatsDbEntry(
+                            TimeSource.now().minusMonths(2).withDayOfMonth(23),
+                            230,
+                            "a-repo-name",
+                            11,
+                            JvmImpl.hotspot
+                    ),
+                    DockerDownloadStatsDbEntry(
+                            TimeSource.now().minusMonths(3).withDayOfMonth(24),
+                            150,
+                            "b-repo-name",
+                            8,
+                            JvmImpl.hotspot
+                    ),
+                    DockerDownloadStatsDbEntry(
+                            TimeSource.now().minusMonths(4).withDayOfMonth(19),
+                            50,
+                            "a-repo-name",
+                            null,
+                            null
+                    ),
+                    DockerDownloadStatsDbEntry(
+                            TimeSource.now().minusMonths(4).withDayOfMonth(19),
+                            50,
+                            "b-repo-name",
+                            null,
+                            null
+                    )
+            )
+        }
+    }
+
+    @Test
+    fun trackingReturnsSaneData() {
+        runBlocking {
+            RestAssured.given()
+                    .`when`()
+                    .get("/v3/stats/downloads/monthly")
+                    .then()
+                    .body(object : TypeSafeMatcher<String>() {
+
+                        override fun describeTo(description: Description?) {
+                            description!!.appendText("json")
+                        }
+
+                        override fun matchesSafely(p0: String?): Boolean {
+                            val stats = JsonMapper.mapper.readValue(p0, List::class.java)
+                            return stats.size == 3 &&
+                                    (stats[0] as Map<String, *>).get("total") == 350 &&
+                                    (stats[0] as Map<String, *>).get("monthly") == 50 &&
+                                    (stats[1] as Map<String, *>).get("total") == 580 &&
+                                    (stats[1] as Map<String, *>).get("monthly") == 230 &&
+                                    (stats[2] as Map<String, *>).get("total") == 1100 &&
+                                    (stats[2] as Map<String, *>).get("monthly") == 520
+                        }
+                    })
+        }
+    }
+
+    @Test
+    fun trackingFeatureVersionRetrunsSaneData() {
+        runBlocking {
+            RestAssured.given()
+                    .`when`()
+                    .get("/v3/stats/downloads/monthly?feature_version=8")
+                    .then()
+                    .body(object : TypeSafeMatcher<String>() {
+
+                        override fun describeTo(description: Description?) {
+                            description!!.appendText("json")
+                        }
+
+                        override fun matchesSafely(p0: String?): Boolean {
+                            val stats = JsonMapper.mapper.readValue(p0, List::class.java)
+                            return stats.size == 2 &&
+                                    (stats[0] as Map<String, *>).get("total") == 350 &&
+                                    (stats[0] as Map<String, *>).get("monthly") == 250 &&
+                                    (stats[1] as Map<String, *>).get("total") == 1100 &&
+                                    (stats[1] as Map<String, *>).get("monthly") == 750
+                        }
+                    })
+        }
+    }
+
+    @Test
+    fun trackingJvmImplRetrunsSaneData() {
+        runBlocking {
+            RestAssured.given()
+                    .`when`()
+                    .get("/v3/stats/downloads/monthly?jvm_impl=hotspot")
+                    .then()
+                    .body(object : TypeSafeMatcher<String>() {
+
+                        override fun describeTo(description: Description?) {
+                            description!!.appendText("json")
+                        }
+
+                        override fun matchesSafely(p0: String?): Boolean {
+                            val stats = JsonMapper.mapper.readValue(p0, List::class.java)
+                            return stats.size == 2 &&
+                                    (stats[0] as Map<String, *>).get("total") == 505 &&
+                                    (stats[0] as Map<String, *>).get("monthly") == 205 &&
+                                    (stats[1] as Map<String, *>).get("total") == 450 &&
+                                    (stats[1] as Map<String, *>).get("monthly") == -55
+                        }
+                    })
+        }
+    }
+
+    @Test
+    fun trackingDockerRepoRetrunsSaneData() {
+        runBlocking {
+            RestAssured.given()
+                    .`when`()
+                    .get("/v3/stats/downloads/monthly?source=dockerhub&docker_repo=a-repo-name")
+                    .then()
+                    .body(object : TypeSafeMatcher<String>() {
+
+                        override fun describeTo(description: Description?) {
+                            description!!.appendText("json")
+                        }
+
+                        override fun matchesSafely(p0: String?): Boolean {
+                            val stats = JsonMapper.mapper.readValue(p0, List::class.java)
+                            return stats.size == 2 &&
+                                    (stats[0] as Map<String, *>).get("total") == 230 &&
+                                    (stats[0] as Map<String, *>).get("monthly") == 180 &&
+                                    (stats[1] as Map<String, *>).get("total") == 310 &&
+                                    (stats[1] as Map<String, *>).get("monthly") == 80
+                        }
+                    })
+        }
+    }
+}

--- a/adoptopenjdk-api-v3-models/src/main/kotlin/net/adoptopenjdk/api/v3/models/MonthlyDownloadDiff.kt
+++ b/adoptopenjdk-api-v3-models/src/main/kotlin/net/adoptopenjdk/api/v3/models/MonthlyDownloadDiff.kt
@@ -1,0 +1,7 @@
+package net.adoptopenjdk.api.v3.models
+
+class MonthlyDownloadDiff(
+    val month: String,
+    val total: Long,
+    val monthly: Long
+)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

Issue: https://github.com/AdoptOpenJDK/openjdk-api-v3/issues/129

# Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] You added tests to cover the change
- [x] `mvn clean install` build and test completes
- [ ] You changed or added to the documentation

# Changes
#### New filters
- `jvm_impl` can now be used in `/tracking` to filter those results. Works with all of the other filters.
- `feature_version` can now be used with `source=dockerhub`
- Both of these do not include results from the official docker repository, which is detailed in the descriptions

####  Add /monthly endpoint
- Grabs the last entry of each month and uses that as the "final total for that month"
- Monthly stat is calculated between the final totals of each month
- Returns data in the format:
```
{
    "month": "2020-May",
    "monthly": 100,
    "total": 350
}
```
- Currently does this for the last 6 months (inc current month)
- Can manually set the `to` date for this. No `from` yet
- Will probably add a `months` filter, similar to how `days` works for `/tracking`
- Has the same filters as /tracking such as `feature_version`, `source`, `docker_repo` and `jvm_impl`

Signed-off-by: Adam Thorpe <adam.thorpe@ibm.com>