### PR TITLE
Fix `page_size` parameter in AssetsResource and ReleaseListResource

### DIFF
--- a/adoptopenjdk-api-v3-frontend/src/main/kotlin/net/adoptopenjdk/api/v3/Pagination.kt
+++ b/adoptopenjdk-api-v3-frontend/src/main/kotlin/net/adoptopenjdk/api/v3/Pagination.kt
@@ -1,0 +1,23 @@
+package net.adoptopenjdk.api.v3
+
+import kotlin.math.min
+
+object Pagination {
+    private const val defaultPageSizeNum = 10
+    private const val maxPageSizeNum = 500
+    const val defaultPageSize = defaultPageSizeNum.toString()
+    const val maxPageSize = maxPageSizeNum.toString()
+
+    fun <T> getPage(pageSize: Int?, page: Int?, releases: Sequence<T>): List<T>? {
+        val pageSizeNum = min(maxPageSizeNum, (pageSize ?: defaultPageSizeNum))
+        val pageNum = page ?: 0
+
+        val chunked = releases.chunked(pageSizeNum)
+
+        return try {
+            chunked.elementAt(pageNum)
+        } catch (e: IndexOutOfBoundsException) {
+            null
+        }
+    }
+}

--- a/adoptopenjdk-api-v3-frontend/src/main/kotlin/net/adoptopenjdk/api/v3/Pagination.kt
+++ b/adoptopenjdk-api-v3-frontend/src/main/kotlin/net/adoptopenjdk/api/v3/Pagination.kt
@@ -5,7 +5,7 @@ import kotlin.math.min
 
 object Pagination {
     private const val defaultPageSizeNum = 10
-    private const val maxPageSizeNum = 500
+    private const val maxPageSizeNum = 100
     const val defaultPageSize = defaultPageSizeNum.toString()
     const val maxPageSize = maxPageSizeNum.toString()
 

--- a/adoptopenjdk-api-v3-frontend/src/main/kotlin/net/adoptopenjdk/api/v3/Pagination.kt
+++ b/adoptopenjdk-api-v3-frontend/src/main/kotlin/net/adoptopenjdk/api/v3/Pagination.kt
@@ -1,5 +1,6 @@
 package net.adoptopenjdk.api.v3
 
+import javax.ws.rs.NotFoundException
 import kotlin.math.min
 
 object Pagination {
@@ -8,7 +9,7 @@ object Pagination {
     const val defaultPageSize = defaultPageSizeNum.toString()
     const val maxPageSize = maxPageSizeNum.toString()
 
-    fun <T> getPage(pageSize: Int?, page: Int?, releases: Sequence<T>): List<T>? {
+    fun <T> getPage(pageSize: Int?, page: Int?, releases: Sequence<T>): List<T> {
         val pageSizeNum = min(maxPageSizeNum, (pageSize ?: defaultPageSizeNum))
         val pageNum = page ?: 0
 
@@ -17,7 +18,7 @@ object Pagination {
         return try {
             chunked.elementAt(pageNum)
         } catch (e: IndexOutOfBoundsException) {
-            null
+            throw NotFoundException("Page not available")
         }
     }
 }

--- a/adoptopenjdk-api-v3-frontend/src/main/kotlin/net/adoptopenjdk/api/v3/Pagination.kt
+++ b/adoptopenjdk-api-v3-frontend/src/main/kotlin/net/adoptopenjdk/api/v3/Pagination.kt
@@ -5,7 +5,7 @@ import kotlin.math.min
 
 object Pagination {
     private const val defaultPageSizeNum = 10
-    private const val maxPageSizeNum = 100
+    private const val maxPageSizeNum = 20
     const val defaultPageSize = defaultPageSizeNum.toString()
     const val maxPageSize = maxPageSizeNum.toString()
 

--- a/adoptopenjdk-api-v3-frontend/src/main/kotlin/net/adoptopenjdk/api/v3/routes/AssetsResource.kt
+++ b/adoptopenjdk-api-v3-frontend/src/main/kotlin/net/adoptopenjdk/api/v3/routes/AssetsResource.kt
@@ -146,7 +146,7 @@ class AssetsResource {
             .getAdoptRepos()
             .getFilteredReleases(version, releaseFilter, binaryFilter, order)
 
-        return getPage(pageSize, page, releases) ?: throw NotFoundException("Page not available")
+        return getPage(pageSize, page, releases)
     }
 
     private fun parseDate(before: String?): ZonedDateTime? {
@@ -270,7 +270,7 @@ class AssetsResource {
             .getAdoptRepos()
             .getFilteredReleases(releaseFilter, binaryFilter, order)
 
-        return getPage(pageSize, page, releases) ?: throw NotFoundException("Page not available")
+        return getPage(pageSize, page, releases)
     }
 
     data class binaryPermutation(

--- a/adoptopenjdk-api-v3-frontend/src/main/kotlin/net/adoptopenjdk/api/v3/routes/info/ReleaseListResource.kt
+++ b/adoptopenjdk-api-v3-frontend/src/main/kotlin/net/adoptopenjdk/api/v3/routes/info/ReleaseListResource.kt
@@ -19,7 +19,6 @@ import org.eclipse.microprofile.openapi.annotations.parameters.Parameter
 import org.eclipse.microprofile.openapi.annotations.tags.Tag
 import org.jboss.resteasy.annotations.jaxrs.QueryParam
 import javax.ws.rs.GET
-import javax.ws.rs.NotFoundException
 import javax.ws.rs.Path
 import javax.ws.rs.Produces
 import javax.ws.rs.core.MediaType

--- a/adoptopenjdk-api-v3-frontend/src/main/kotlin/net/adoptopenjdk/api/v3/routes/info/ReleaseListResource.kt
+++ b/adoptopenjdk-api-v3-frontend/src/main/kotlin/net/adoptopenjdk/api/v3/routes/info/ReleaseListResource.kt
@@ -65,7 +65,7 @@ class ReleaseListResource {
         val releases = filteredReleases
             .map { it.release_name }
 
-        val pagedReleases = getPage(pageSize, page, releases) ?: throw NotFoundException("Page not available")
+        val pagedReleases = getPage(pageSize, page, releases)
 
         return ReleaseList(pagedReleases.toTypedArray())
     }
@@ -107,7 +107,7 @@ class ReleaseListResource {
             .map { it.version_data }
             .distinct()
 
-        val pagedReleases = getPage(pageSize, page, releases) ?: throw NotFoundException("Page not available")
+        val pagedReleases = getPage(pageSize, page, releases)
 
         return ReleaseVersionList(pagedReleases.toTypedArray())
     }

--- a/adoptopenjdk-api-v3-frontend/src/test/kotlin/net/adoptopenjdk/api/AssetsResourceFeatureReleasePathTest.kt
+++ b/adoptopenjdk-api-v3-frontend/src/test/kotlin/net/adoptopenjdk/api/AssetsResourceFeatureReleasePathTest.kt
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.DynamicTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestFactory
 import java.util.stream.Stream
+import kotlin.test.assertTrue
 
 @QuarkusTest
 class AssetsResourceFeatureReleasePathTest : AssetsPathTest() {
@@ -117,17 +118,32 @@ class AssetsResourceFeatureReleasePathTest : AssetsPathTest() {
                 .body
 
             val releasesStr = body.prettyPrint()
-            return JsonMapper.mapper.readValue(releasesStr, JsonMapper.mapper.getTypeFactory().constructCollectionType(MutableList::class.java, Release::class.java))
+            return parseReleases(releasesStr)
         }
+        fun parseReleases(json: String?): List<Release> =
+                JsonMapper.mapper.readValue(json, JsonMapper.mapper.getTypeFactory().constructCollectionType(MutableList::class.java, Release::class.java))
     }
 
     @Test
     fun pagination() {
         RestAssured.given()
             .`when`()
-            .get("${getPath()}/8/ga?pageSize=1&page=1")
+            .get("${getPath()}/8/ga?page_size=1&page=1")
             .then()
             .statusCode(200)
+    }
+
+    @Test
+    fun pageSizeIsWorking() {
+        val body = RestAssured.given()
+                .`when`()
+                .get("${getPath()}/11/ea?page_size=5")
+                .body
+
+        val releasesStr = body.prettyPrint()
+        val releases = parseReleases(releasesStr)
+
+        assertTrue { releases.size == 5 }
     }
 
     @TestFactory

--- a/adoptopenjdk-api-v3-frontend/src/test/kotlin/net/adoptopenjdk/api/ReleaseNamesPathTest.kt
+++ b/adoptopenjdk-api-v3-frontend/src/test/kotlin/net/adoptopenjdk/api/ReleaseNamesPathTest.kt
@@ -2,10 +2,19 @@ package net.adoptopenjdk.api
 
 import io.quarkus.test.junit.QuarkusTest
 import io.restassured.RestAssured
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 
 @QuarkusTest
 class ReleaseNamesPathTest : BaseTest() {
+    companion object {
+        @JvmStatic
+        @BeforeAll
+        fun before() {
+            populateDb()
+        }
+    }
+
     @Test
     fun releaseNames() {
 

--- a/adoptopenjdk-api-v3-frontend/src/test/kotlin/net/adoptopenjdk/api/ReleaseNamesPathTest.kt
+++ b/adoptopenjdk-api-v3-frontend/src/test/kotlin/net/adoptopenjdk/api/ReleaseNamesPathTest.kt
@@ -17,6 +17,16 @@ class ReleaseNamesPathTest : BaseTest() {
     }
 
     @Test
+    fun releaseNamesPageSize() {
+
+        RestAssured.given()
+                .`when`()
+                .get("/v3/info/release_names?page_size=50")
+                .then()
+                .statusCode(200)
+    }
+
+    @Test
     fun releaseNamesSortOrder() {
 
         RestAssured.given()
@@ -32,6 +42,16 @@ class ReleaseNamesPathTest : BaseTest() {
         RestAssured.given()
                 .`when`()
                 .get("/v3/info/release_versions")
+                .then()
+                .statusCode(200)
+    }
+
+    @Test
+    fun releaseVersionsPageSize() {
+
+        RestAssured.given()
+                .`when`()
+                .get("/v3/info/release_versions?page_size=50")
                 .then()
                 .statusCode(200)
     }

--- a/adoptopenjdk-api-v3-frontend/src/test/kotlin/net/adoptopenjdk/api/VersionPathTest.kt
+++ b/adoptopenjdk-api-v3-frontend/src/test/kotlin/net/adoptopenjdk/api/VersionPathTest.kt
@@ -58,4 +58,17 @@ class VersionPathTest {
                 .then()
                 .statusCode(400)
     }
+
+    @Test
+    fun supportsPageSize() {
+
+        val parsed = VersionParser.parse("jdk-11.0.5+10")
+
+        RestAssured.given()
+                .`when`()
+                .get("/v3/version/jdk-11.0.5+10?page_size=50")
+                .then()
+                .statusCode(200)
+                .body(VersionDataMatcher(parsed))
+    }
 }


### PR DESCRIPTION
The `page_size` query parameter was incorrectly handled in `AssetsResource` and capped to an undocumented limit of 20 items per page.

In `ReleaseListResource`, the `page_size` query parameter wasn't used at all, although documented in the API specification (via Swagger).

Fixes #184

# Checklist

- [x] You added tests to cover the change
- [x] `mvn clean install` build and test completes