### PR TITLE
Explicitly set serverSelectionTimeoutMS for 'fallback' Mongo connection string

### DIFF
--- a/adoptopenjdk-api-v3-persistance/src/main/kotlin/net/adoptopenjdk/api/v3/dataSources/persitence/mongo/MongoClient.kt
+++ b/adoptopenjdk-api-v3-persistance/src/main/kotlin/net/adoptopenjdk/api/v3/dataSources/persitence/mongo/MongoClient.kt
@@ -42,7 +42,7 @@ class MongoClient {
         var uri = if (username != null && password != null) {
             "mongodb://$username:$password@$host:$port/$dbName"
         } else {
-            "mongodb://$host:$port"
+            "mongodb://$host:$port/?serverSelectionTimeoutMS=100"
         }
 
         if (System.getProperty("MONGO_DB") != null) {


### PR DESCRIPTION
When the tests are executed a number of attempts are made to initialise the
MongoClient before the Mongo instance has been initialised. By default, this
triggers a 30000ms timeout for each attempt.

The 'fallback' Mongo connection string is only used when the
Mongo user & password environment variables are not passed and therefore
only applies for local development/testing use-cases.

This change shortens the timeout to 100ms reducing overall test suite execution
time from ~40 mins to ~8 mins.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

Fixes #238

# Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->


- [x] `mvn clean install` build and test completes