### PR TITLE
Refactor mongo client connection string

### DIFF
--- a/adoptopenjdk-api-v3-persistance/pom.xml
+++ b/adoptopenjdk-api-v3-persistance/pom.xml
@@ -41,9 +41,15 @@
             <groupId>org.mongodb</groupId>
             <artifactId>mongodb-driver-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
         <sourceDirectory>src/main/kotlin</sourceDirectory>
+        <testSourceDirectory>src/test/kotlin</testSourceDirectory>
     </build>
 </project>

--- a/adoptopenjdk-api-v3-persistance/src/main/kotlin/net/adoptopenjdk/api/v3/dataSources/persitence/mongo/MongoClient.kt
+++ b/adoptopenjdk-api-v3-persistance/src/main/kotlin/net/adoptopenjdk/api/v3/dataSources/persitence/mongo/MongoClient.kt
@@ -45,7 +45,7 @@ class MongoClient {
         val host = System.getenv("MONGODB_HOST") ?: DefaultMongoClientConfig.HOST
         val port = System.getenv("MONGODB_PORT") ?: DefaultMongoClientConfig.PORT
 
-        val uri = System.getProperty("MONGODB_TEST_CONNECTION_STRING")
+        val connectionString = System.getProperty("MONGODB_TEST_CONNECTION_STRING")
                 ?: if (username != null && password != null) {
                     LOGGER.info("Connecting to mongodb://$username:a-password@$host:$port/$dbName")
                     "mongodb://$username:$password@$host:$port/$dbName"
@@ -56,7 +56,7 @@ class MongoClient {
                     developmentConnectionString
                 }
 
-        client = KMongo.createClient(uri).coroutine
+        client = KMongo.createClient(connectionString).coroutine
         database = client.getDatabase(dbName)
     }
 }

--- a/adoptopenjdk-api-v3-persistance/src/main/kotlin/net/adoptopenjdk/api/v3/dataSources/persitence/mongo/MongoClient.kt
+++ b/adoptopenjdk-api-v3-persistance/src/main/kotlin/net/adoptopenjdk/api/v3/dataSources/persitence/mongo/MongoClient.kt
@@ -22,13 +22,6 @@ object MongoClientFactory {
     }
 }
 
-object DefaultMongoClientConfig {
-    const val DBNAME = "api-data"
-    const val HOST = "localhost"
-    const val PORT = "27017"
-    const val SERVER_SELECTION_TIMEOUT_MILLIS = 100
-}
-
 class MongoClient {
     val database: CoroutineDatabase
     val client: CoroutineClient

--- a/adoptopenjdk-api-v3-persistance/src/main/kotlin/net/adoptopenjdk/api/v3/dataSources/persitence/mongo/MongoClient.kt
+++ b/adoptopenjdk-api-v3-persistance/src/main/kotlin/net/adoptopenjdk/api/v3/dataSources/persitence/mongo/MongoClient.kt
@@ -22,6 +22,13 @@ object MongoClientFactory {
     }
 }
 
+object DefaultMongoClientConfig {
+    const val DBNAME = "api-data"
+    const val HOST = "localhost"
+    const val PORT = "27017"
+    const val SERVER_SELECTION_TIMEOUT_MILLIS = 100
+}
+
 class MongoClient {
     val database: CoroutineDatabase
     val client: CoroutineClient
@@ -32,20 +39,22 @@ class MongoClient {
     }
 
     init {
-        val dbName = System.getenv("MONGODB_DBNAME") ?: "api-data"
+        val dbName = System.getenv("MONGODB_DBNAME") ?: DefaultMongoClientConfig.DBNAME
         val username = System.getenv("MONGODB_USER")
         val password = System.getenv("MONGODB_PASSWORD")
-        val host = System.getenv("MONGODB_HOST") ?: "localhost"
-        val port = System.getenv("MONGODB_PORT") ?: "27017"
+        val host = System.getenv("MONGODB_HOST") ?: DefaultMongoClientConfig.HOST
+        val port = System.getenv("MONGODB_PORT") ?: DefaultMongoClientConfig.PORT
 
-        LOGGER.info("Connecting to mongodb://$username:a-password@$host:$port/$dbName")
-        var uri = if (System.getProperty("MONGO_DB") != null) {
-            System.getProperty("MONGO_DB")
-        } else if (username != null && password != null) {
-            "mongodb://$username:$password@$host:$port/$dbName"
-        } else {
-            "mongodb://$host:$port"
-        }
+        val uri = System.getProperty("MONGODB_TEST_CONNECTION_STRING")
+                ?: if (username != null && password != null) {
+                    LOGGER.info("Connecting to mongodb://$username:a-password@$host:$port/$dbName")
+                    "mongodb://$username:$password@$host:$port/$dbName"
+                } else {
+                    val serverSelectionTimeoutMills = System.getenv("MONGODB_SERVER_SELECTION_TIMEOUT_MILLIS") ?: DefaultMongoClientConfig.SERVER_SELECTION_TIMEOUT_MILLIS
+                    val developmentConnectionString = "mongodb://$host:$port/?serverSelectionTimeoutMS=$serverSelectionTimeoutMills"
+                    LOGGER.info("Using development connection string - $developmentConnectionString")
+                    developmentConnectionString
+                }
 
         client = KMongo.createClient(uri).coroutine
         database = client.getDatabase(dbName)

--- a/adoptopenjdk-api-v3-persistance/src/main/kotlin/net/adoptopenjdk/api/v3/dataSources/persitence/mongo/MongoClient.kt
+++ b/adoptopenjdk-api-v3-persistance/src/main/kotlin/net/adoptopenjdk/api/v3/dataSources/persitence/mongo/MongoClient.kt
@@ -39,14 +39,12 @@ class MongoClient {
         val port = System.getenv("MONGODB_PORT") ?: "27017"
 
         LOGGER.info("Connecting to mongodb://$username:a-password@$host:$port/$dbName")
-        var uri = if (username != null && password != null) {
+        var uri = if (System.getProperty("MONGO_DB") != null) {
+            System.getProperty("MONGO_DB")
+        } else if (username != null && password != null) {
             "mongodb://$username:$password@$host:$port/$dbName"
         } else {
             "mongodb://$host:$port"
-        }
-
-        if (System.getProperty("MONGO_DB") != null) {
-            uri = System.getProperty("MONGO_DB")
         }
 
         client = KMongo.createClient(uri).coroutine

--- a/adoptopenjdk-api-v3-persistance/src/test/kotlin/net/adoptopenjdk/api/v3/dataSources/persitence/mongo/MongoClientTest.kt
+++ b/adoptopenjdk-api-v3-persistance/src/test/kotlin/net/adoptopenjdk/api/v3/dataSources/persitence/mongo/MongoClientTest.kt
@@ -1,0 +1,38 @@
+package net.adoptopenjdk.api.v3.dataSources.persitence.mongo
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class MongoClientTest {
+
+    @Test
+    fun `default connection string`() {
+        val connectionString = MongoClient.createConnectionString("api-data")
+        assertEquals(connectionString, "mongodb://localhost:27017/?serverSelectionTimeoutMS=100")
+    }
+
+    @Test
+    fun `default connection string with explicit server selection timeout`() {
+        val connectionString = MongoClient.createConnectionString("api-data", serverSelectionTimeoutMills = "999")
+        assertEquals(connectionString, "mongodb://localhost:27017/?serverSelectionTimeoutMS=999")
+    }
+
+    @Test
+    fun `override with test connection string`() {
+        System.setProperty("MONGODB_TEST_CONNECTION_STRING", "mongodb://some-host:99999")
+        val connectionString = MongoClient.createConnectionString("api-data")
+        assertEquals(connectionString, "mongodb://some-host:99999")
+    }
+
+    @Test
+    fun `fully specified connection string`() {
+        val connectionString = MongoClient.createConnectionString(
+            "api-data",
+            "some-user",
+            "some-password",
+            "some-host",
+            "12345"
+        )
+        assertEquals(connectionString, "mongodb://some-user:some-password@some-host:12345/api-data")
+    }
+}

--- a/adoptopenjdk-api-v3-updater/src/test/kotlin/net/adoptopenjdk/api/BaseTest.kt
+++ b/adoptopenjdk-api-v3-updater/src/test/kotlin/net/adoptopenjdk/api/BaseTest.kt
@@ -101,7 +101,7 @@ abstract class BaseTest {
                 .net(Net(bindIp, port, Network.localhostIsIPv6()))
                 .build()
 
-            val mongodbTestConnectionString = "mongodb://${bindIp}:${port}"
+            val mongodbTestConnectionString = "mongodb://$bindIp:$port"
             LOGGER.info("Mongo test connection string - $mongodbTestConnectionString")
             System.setProperty("MONGODB_TEST_CONNECTION_STRING", mongodbTestConnectionString)
 

--- a/adoptopenjdk-api-v3-updater/src/test/kotlin/net/adoptopenjdk/api/BaseTest.kt
+++ b/adoptopenjdk-api-v3-updater/src/test/kotlin/net/adoptopenjdk/api/BaseTest.kt
@@ -101,8 +101,9 @@ abstract class BaseTest {
                 .net(Net(bindIp, port, Network.localhostIsIPv6()))
                 .build()
 
-            LOGGER.info("Mongo \"mongodb://localhost:${port}\"")
-            System.setProperty("MONGO_DB", "mongodb://localhost:$port")
+            val mongodbTestConnectionString = "mongodb://${bindIp}:${port}"
+            LOGGER.info("Mongo test connection string - $mongodbTestConnectionString")
+            System.setProperty("MONGODB_TEST_CONNECTION_STRING", mongodbTestConnectionString)
 
             mongodExecutable = starter.prepare(mongodConfig)
             mongodExecutable!!.start()


### PR DESCRIPTION
This PR aims to clarify and simplify the login for the MongoClient connection string.

The changes are:
- Rename the `MONGO_DB` property set in `BaseTest` to `MONGODB_TEST_CONNECTION_STRING` 
  - from the code this value is only used by tests so this name makes its intent clearer
  - if in fact this is used for other purposes (e.g. production config) then we can revert this and document it
- Test the value of `MONGODB_TEST_CONNECTION_STRING` (previously `MONGO_DB`) first when initialising the MongoClient
  - when non-null it overrides any previous values so it makes sense from a logic perspective to check this first
- Clearly log which connection string is being used when `MongoClient` is initialised
  - this is useful for debugging purposes whereas previously a potentially misleading connection string would be logged

I set out with the intent to also expose `serverSelectionTimeoutMS` as an application property however this doesn't appear to be straightforward as the `MongoClient` class isn't created within the context of the Quarkus/JAX RS Application and therefore annotations such as `@ConfigProperty` as described [here](https://quarkus.io/guides/config) can't be used.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

# Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] You added tests to cover the change
- [x] `mvn clean install` build and test completes
- [ ] You changed or added to the documentation