### PR TITLE
Expose metadata_link for binary assets

### DIFF
--- a/adoptopenjdk-api-v3-frontend/src/test/kotlin/net/adoptopenjdk/api/AssetsResourceFeatureReleasePathSortOrderTest.kt
+++ b/adoptopenjdk-api-v3-frontend/src/test/kotlin/net/adoptopenjdk/api/AssetsResourceFeatureReleasePathSortOrderTest.kt
@@ -63,7 +63,8 @@ class AssetsResourceFeatureReleasePathSortOrderTest : BaseTest() {
                 "v",
                 "c",
                 3,
-                "d"
+                "d",
+                "e"
             ),
             2L,
             TimeSource.now(),
@@ -73,7 +74,9 @@ class AssetsResourceFeatureReleasePathSortOrderTest : BaseTest() {
                 1L,
                 "v",
                 "c",
-                4
+                4,
+                "d,",
+                "e"
             ),
             HeapSize.normal,
             OperatingSystem.linux,

--- a/adoptopenjdk-api-v3-models/src/main/kotlin/net/adoptopenjdk/api/v3/models/Asset.kt
+++ b/adoptopenjdk-api-v3-models/src/main/kotlin/net/adoptopenjdk/api/v3/models/Asset.kt
@@ -25,6 +25,9 @@ open class Asset {
     @Schema(example = "2")
     val download_count: Long
 
+    @Schema(example = "https://github.com/AdoptOpenJDK/openjdk8-openj9-releases/ga/download/jdk8u162-b12_openj9-0.8.0/OpenJDK8-OPENJ9_x64_Linux_jdk8u162-b12_openj9-0.8.0.tar.gz.json")
+    val metadata_link: String?
+
     constructor(
         name: String,
         link: String,
@@ -32,7 +35,8 @@ open class Asset {
         checksum: String?,
         checksum_link: String?,
         signature_link: String?,
-        download_count: Long
+        download_count: Long,
+        metadata_link: String?
     ) {
         this.name = name
         this.link = link
@@ -41,6 +45,7 @@ open class Asset {
         this.checksum_link = checksum_link
         this.signature_link = signature_link
         this.download_count = download_count
+        this.metadata_link = metadata_link
     }
 
     override fun equals(other: Any?): Boolean {
@@ -55,6 +60,7 @@ open class Asset {
         if (checksum != other.checksum) return false
         if (checksum_link != other.checksum_link) return false
         if (signature_link != other.signature_link) return false
+        if (metadata_link != other.metadata_link) return false
 
         return true
     }
@@ -66,6 +72,7 @@ open class Asset {
         result = 31 * result + (checksum?.hashCode() ?: 0)
         result = 31 * result + (checksum_link?.hashCode() ?: 0)
         result = 31 * result + (signature_link?.hashCode() ?: 0)
+        result = 31 * result + (metadata_link?.hashCode() ?: 0)
         return result
     }
 }

--- a/adoptopenjdk-api-v3-models/src/main/kotlin/net/adoptopenjdk/api/v3/models/Asset.kt
+++ b/adoptopenjdk-api-v3-models/src/main/kotlin/net/adoptopenjdk/api/v3/models/Asset.kt
@@ -75,4 +75,9 @@ open class Asset {
         result = 31 * result + (metadata_link?.hashCode() ?: 0)
         return result
     }
+
+    override fun toString(): String {
+        return "Asset(name='$name', link='$link', size=$size, checksum=$checksum, checksum_link=$checksum_link, signature_link=$signature_link, download_count=$download_count, metadata_link=$metadata_link)"
+    }
+
 }

--- a/adoptopenjdk-api-v3-models/src/main/kotlin/net/adoptopenjdk/api/v3/models/Asset.kt
+++ b/adoptopenjdk-api-v3-models/src/main/kotlin/net/adoptopenjdk/api/v3/models/Asset.kt
@@ -79,5 +79,4 @@ open class Asset {
     override fun toString(): String {
         return "Asset(name='$name', link='$link', size=$size, checksum=$checksum, checksum_link=$checksum_link, signature_link=$signature_link, download_count=$download_count, metadata_link=$metadata_link)"
     }
-
 }

--- a/adoptopenjdk-api-v3-models/src/main/kotlin/net/adoptopenjdk/api/v3/models/Binary.kt
+++ b/adoptopenjdk-api-v3-models/src/main/kotlin/net/adoptopenjdk/api/v3/models/Binary.kt
@@ -99,4 +99,10 @@ class Binary {
         result = 31 * result + project.hashCode()
         return result
     }
+
+    override fun toString(): String {
+        return "Binary(os=$os, architecture=$architecture, image_type=$image_type, jvm_impl=$jvm_impl, `package`=$`package`, installer=$installer, heap_size=$heap_size, download_count=$download_count, updated_at=$updated_at, scm_ref=$scm_ref, project=$project)"
+    }
+
+
 }

--- a/adoptopenjdk-api-v3-models/src/main/kotlin/net/adoptopenjdk/api/v3/models/Binary.kt
+++ b/adoptopenjdk-api-v3-models/src/main/kotlin/net/adoptopenjdk/api/v3/models/Binary.kt
@@ -103,6 +103,4 @@ class Binary {
     override fun toString(): String {
         return "Binary(os=$os, architecture=$architecture, image_type=$image_type, jvm_impl=$jvm_impl, `package`=$`package`, installer=$installer, heap_size=$heap_size, download_count=$download_count, updated_at=$updated_at, scm_ref=$scm_ref, project=$project)"
     }
-
-
 }

--- a/adoptopenjdk-api-v3-models/src/main/kotlin/net/adoptopenjdk/api/v3/models/Installer.kt
+++ b/adoptopenjdk-api-v3-models/src/main/kotlin/net/adoptopenjdk/api/v3/models/Installer.kt
@@ -7,5 +7,6 @@ class Installer(
     checksum: String?,
     checksum_link: String?,
     download_count: Long,
-    signature_link: String? = null
-) : Asset(name, link, size, checksum, checksum_link, signature_link, download_count)
+    signature_link: String? = null,
+    metadata_link: String?
+) : Asset(name, link, size, checksum, checksum_link, signature_link, download_count, metadata_link)

--- a/adoptopenjdk-api-v3-models/src/main/kotlin/net/adoptopenjdk/api/v3/models/Package.kt
+++ b/adoptopenjdk-api-v3-models/src/main/kotlin/net/adoptopenjdk/api/v3/models/Package.kt
@@ -7,5 +7,6 @@ class Package(
     checksum: String?,
     checksum_link: String?,
     download_count: Long,
-    signature_link: String? = null
-) : Asset(name, link, size, checksum, checksum_link, signature_link, download_count)
+    signature_link: String? = null,
+    metadata_link: String?
+) : Asset(name, link, size, checksum, checksum_link, signature_link, download_count, metadata_link)

--- a/adoptopenjdk-api-v3-updater/src/main/kotlin/net/adoptopenjdk/api/v3/mapping/ReleaseMapper.kt
+++ b/adoptopenjdk-api-v3-updater/src/main/kotlin/net/adoptopenjdk/api/v3/mapping/ReleaseMapper.kt
@@ -8,7 +8,7 @@ import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 
 abstract class ReleaseMapper {
-    abstract suspend fun toAdoptRelease(release: GHRelease): ReleaseResult
+    abstract suspend fun toAdoptRelease(ghRelease: GHRelease): ReleaseResult
 
     companion object {
         fun parseDate(date: String): ZonedDateTime {

--- a/adoptopenjdk-api-v3-updater/src/main/kotlin/net/adoptopenjdk/api/v3/mapping/adopt/AdoptReleaseMapper.kt
+++ b/adoptopenjdk-api-v3-updater/src/main/kotlin/net/adoptopenjdk/api/v3/mapping/adopt/AdoptReleaseMapper.kt
@@ -29,60 +29,63 @@ object AdoptReleaseMapper : ReleaseMapper() {
     private val LOGGER = LoggerFactory.getLogger(this::class.java)
     private val excludedReleases: MutableSet<GithubId> = mutableSetOf()
 
-    override suspend fun toAdoptRelease(release: GHRelease): ReleaseResult {
-        if (excludedReleases.contains(release.id)) {
+    override suspend fun toAdoptRelease(ghRelease: GHRelease): ReleaseResult {
+        if (excludedReleases.contains(ghRelease.id)) {
             return ReleaseResult(error = "Excluded")
         }
 
-        val releaseType: ReleaseType = formReleaseType(release)
+        val releaseType: ReleaseType = formReleaseType(ghRelease)
 
-        val releaseLink = release.url
-        val releaseName = release.name
-        val timestamp = parseDate(release.publishedAt)
-        val updatedAt = parseDate(release.updatedAt)
+        val releaseLink = ghRelease.url
+        val releaseName = ghRelease.name
+        val timestamp = parseDate(ghRelease.publishedAt)
+        val updatedAt = parseDate(ghRelease.updatedAt)
         val vendor = Vendor.adoptopenjdk
 
-        val metadata = getMetadata(release.releaseAssets)
+        val ghAssetsWithMetadata = associateMetadataWithBinaries(ghRelease.releaseAssets)
 
         try {
-            val groupedByVersion = metadata
-                .entries
-                .groupBy {
-                    val version = it.value.version
-                    "${version.major}.${version.minor}.${version.security}.${version.build}.${version.adopt_build_number}.${version.pre}"
-                }
+            val ghAssetsGroupedByVersion = ghAssetsWithMetadata
+                    .entries
+                    .groupBy(this@AdoptReleaseMapper::getReleaseVersion)
 
-            val releases = groupedByVersion
-                .entries
-                .map { grouped ->
-                    val version = grouped.value.sortedBy { it.value.version.toApiVersion() }
-                        .last().value.version.toApiVersion()
+            val releases = ghAssetsGroupedByVersion
+                    .entries
+                    .map { ghAssetsForVersion: Map.Entry<String, List<Map.Entry<GHAsset, GHMetaData>>> ->
+                        val version = ghAssetsForVersion.value
+                            .sortedBy { ghAssetWithMetadata -> ghAssetWithMetadata.value.version.toApiVersion() }
+                            .last().value.version.toApiVersion()
 
-                    val assets = grouped.value.map { it.key }
-                    val id = generateIdForSplitRelease(version, release)
+                        val ghAssets: List<GHAsset> = ghAssetsForVersion.value.map { ghAssetWithMetadata -> ghAssetWithMetadata.key }
+                        val id = generateIdForSplitRelease(version, ghRelease)
 
-                    toRelease(releaseName, assets, metadata, id, releaseType, releaseLink, timestamp, updatedAt, vendor, version, release.releaseAssets.assets)
-                }
-                .ifEmpty {
-                    try {
-                        // if we have no metadata resort to parsing release names
-                        val version = parseVersionInfo(release, releaseName)
-                        val assets = release.releaseAssets.assets
-                        val id = release.id.githubId
-
-                        return@ifEmpty listOf(toRelease(releaseName, assets, metadata, id, releaseType, releaseLink, timestamp, updatedAt, vendor, version, assets))
-                    } catch (e: Exception) {
-                        throw FailedToParse("Failed to parse version $releaseName", e)
+                        toRelease(releaseName, ghAssets, ghAssetsWithMetadata, id, releaseType, releaseLink, timestamp, updatedAt, vendor, version, ghRelease.releaseAssets.assets)
                     }
-                }
-                .filter { updatedRelease -> !excludeRelease(release, updatedRelease) }
+                    .ifEmpty {
+                        try {
+                            // if we have no metadata resort to parsing release names
+                            val version = parseVersionInfo(ghRelease, releaseName)
+                            val ghAssets = ghRelease.releaseAssets.assets
+                            val id = ghRelease.id.githubId
+
+                            return@ifEmpty listOf(toRelease(releaseName, ghAssets, ghAssetsWithMetadata, id, releaseType, releaseLink, timestamp, updatedAt, vendor, version, ghAssets))
+                        } catch (e: Exception) {
+                            throw FailedToParse("Failed to parse version $releaseName", e)
+                        }
+                    }
+                    .filter { updatedRelease -> !excludeRelease(ghRelease, updatedRelease) }
 
             return ReleaseResult(result = releases)
         } catch (e: FailedToParse) {
-            excludedReleases.add(release.id)
+            excludedReleases.add(ghRelease.id)
             LOGGER.error("Failed to parse $releaseName")
             return ReleaseResult(error = "Failed to parse $releaseName")
         }
+    }
+
+    private fun getReleaseVersion(ghAssetWithMetadata: Map.Entry<GHAsset, GHMetaData>): String {
+        val version = ghAssetWithMetadata.value.version
+        return "${version.major}.${version.minor}.${version.security}.${version.build}.${version.adopt_build_number}.${version.pre}"
     }
 
     private fun excludeRelease(ghRelease: GHRelease, release: Release): Boolean {
@@ -118,8 +121,8 @@ object AdoptReleaseMapper : ReleaseMapper() {
 
     private suspend fun toRelease(
         releaseName: String,
-        assets: List<GHAsset>,
-        metadata: Map<GHAsset, GHMetaData>,
+        ghAssets: List<GHAsset>,
+        ghAssetWithMetadata: Map<GHAsset, GHMetaData>,
         id: String,
         release_type: ReleaseType,
         releaseLink: String,
@@ -127,13 +130,13 @@ object AdoptReleaseMapper : ReleaseMapper() {
         updatedAt: ZonedDateTime,
         vendor: Vendor,
         version: VersionData,
-        fullAssetList: List<GHAsset>
+        fullGhAssetList: List<GHAsset>
     ): Release {
         LOGGER.info("Getting binaries $releaseName")
-        val binaries = AdoptBinaryMapper.toBinaryList(assets, fullAssetList, metadata)
+        val binaries = AdoptBinaryMapper.toBinaryList(ghAssets, fullGhAssetList, ghAssetWithMetadata)
         LOGGER.info("Done Getting binaries $releaseName")
 
-        val downloadCount = assets
+        val downloadCount = ghAssets
             .filter { asset ->
                 BinaryMapper.BINARY_EXTENSIONS.any { asset.name.endsWith(it) }
             }
@@ -176,7 +179,7 @@ object AdoptReleaseMapper : ReleaseMapper() {
         }
     }
 
-    private suspend fun getMetadata(releaseAssets: GHAssets): Map<GHAsset, GHMetaData> {
+    private suspend fun associateMetadataWithBinaries(releaseAssets: GHAssets): Map<GHAsset, GHMetaData> {
         return releaseAssets
             .assets
             .filter { it.name.endsWith(".json") }

--- a/adoptopenjdk-api-v3-updater/src/main/kotlin/net/adoptopenjdk/api/v3/mapping/upstream/UpstreamBinaryMapper.kt
+++ b/adoptopenjdk-api-v3-updater/src/main/kotlin/net/adoptopenjdk/api/v3/mapping/upstream/UpstreamBinaryMapper.kt
@@ -36,7 +36,7 @@ object UpstreamBinaryMapper : BinaryMapper() {
         return GlobalScope.async {
             try {
                 val signatureLink = getSignatureLink(assets, asset.name)
-                val pack = Package(asset.name, asset.downloadUrl, asset.size, null, null, asset.downloadCount, signatureLink)
+                val pack = Package(asset.name, asset.downloadUrl, asset.size, null, null, asset.downloadCount, signatureLink, null)
 
                 val os = getEnumFromFileName(asset.name, OperatingSystem.values())
                 val architecture = getEnumFromFileName(asset.name, Architecture.values())

--- a/adoptopenjdk-api-v3-updater/src/main/kotlin/net/adoptopenjdk/api/v3/mapping/upstream/UpstreamReleaseMapper.kt
+++ b/adoptopenjdk-api-v3-updater/src/main/kotlin/net/adoptopenjdk/api/v3/mapping/upstream/UpstreamReleaseMapper.kt
@@ -19,14 +19,14 @@ object UpstreamReleaseMapper : ReleaseMapper() {
     @JvmStatic
     private val LOGGER = LoggerFactory.getLogger(this::class.java)
 
-    override suspend fun toAdoptRelease(release: GHRelease): ReleaseResult {
-        val release_type: ReleaseType = if (release.name.contains(" GA ")) ReleaseType.ga else ReleaseType.ea
+    override suspend fun toAdoptRelease(ghRelease: GHRelease): ReleaseResult {
+        val release_type: ReleaseType = if (ghRelease.name.contains(" GA ")) ReleaseType.ga else ReleaseType.ea
 
-        val releaseLink = release.url
-        val releaseName = release.name
-        val timestamp = parseDate(release.publishedAt)
-        val updatedAt = parseDate(release.updatedAt)
-        val downloadCount = release.releaseAssets.assets
+        val releaseLink = ghRelease.url
+        val releaseName = ghRelease.name
+        val timestamp = parseDate(ghRelease.publishedAt)
+        val updatedAt = parseDate(ghRelease.updatedAt)
+        val downloadCount = ghRelease.releaseAssets.assets
             .filter { asset ->
                 BinaryMapper.BINARY_EXTENSIONS.any { asset.name.endsWith(it) }
             }
@@ -35,7 +35,7 @@ object UpstreamReleaseMapper : ReleaseMapper() {
         val vendor = Vendor.openjdk
 
         LOGGER.info("Getting binaries $releaseName")
-        val binaries = UpstreamBinaryMapper.toBinaryList(release.releaseAssets.assets)
+        val binaries = UpstreamBinaryMapper.toBinaryList(ghRelease.releaseAssets.assets)
         LOGGER.info("Done Getting binaries $releaseName")
 
         try {
@@ -49,9 +49,9 @@ object UpstreamReleaseMapper : ReleaseMapper() {
                 versionData = getVersionData(releaseName)
             }
 
-            val sourcePackage = getSourcePackage(release)
+            val sourcePackage = getSourcePackage(ghRelease)
 
-            return ReleaseResult(result = listOf(Release(release.id.githubId, release_type, releaseLink, releaseName, timestamp, updatedAt, binaries.toTypedArray(), downloadCount, vendor, versionData, sourcePackage)))
+            return ReleaseResult(result = listOf(Release(ghRelease.id.githubId, release_type, releaseLink, releaseName, timestamp, updatedAt, binaries.toTypedArray(), downloadCount, vendor, versionData, sourcePackage)))
         } catch (e: FailedToParse) {
             LOGGER.error("Failed to parse $releaseName")
             return ReleaseResult(error = "Failed to parse")

--- a/adoptopenjdk-api-v3-updater/src/test/kotlin/net/adoptopenjdk/api/AdoptBinaryMapperTest.kt
+++ b/adoptopenjdk-api-v3-updater/src/test/kotlin/net/adoptopenjdk/api/AdoptBinaryMapperTest.kt
@@ -177,7 +177,7 @@ class AdoptBinaryMapperTest {
     }
 
     @Test
-    fun oldChecksumIsFound() {
+    fun `old checksum is found`() {
         runBlocking {
             val assets = listOf(GHAsset(
                 "OpenJDK9-OPENJ9_ppc64le_Linux_jdk-9.0.4.12_openj9-0.9.0.tar.gz",
@@ -201,7 +201,7 @@ class AdoptBinaryMapperTest {
     }
 
     @Test
-    fun parsesOldOpenj9() {
+    fun `parses old OpenJ9`() {
         runBlocking {
             val assets = listOf(GHAsset(
                 "OpenJDK9-OPENJ9_ppc64le_Linux_jdk-9.0.4.12_openj9-0.9.0.tar.gz",
@@ -221,7 +221,7 @@ class AdoptBinaryMapperTest {
     }
 
     @Test
-    fun parsesJfrFromName() {
+    fun `parses JFR from name`() {
         runBlocking {
             val binaryList = AdoptBinaryMapper.toBinaryList(assets, assets, emptyMap())
             assertParsedHotspotJfr(binaryList)
@@ -229,7 +229,7 @@ class AdoptBinaryMapperTest {
     }
 
     @Test
-    fun projectDefaultsToJdk() {
+    fun `project defaults to jdk`() {
         runBlocking {
             val binaryList = AdoptBinaryMapper.toBinaryList(assets, assets, emptyMap())
             assertEquals(Project.jdk, binaryList[1].project)
@@ -237,8 +237,7 @@ class AdoptBinaryMapperTest {
     }
 
     @Test
-    fun parsesJfrFromMetadata() {
-
+    fun `parses JFR from metadata`() {
         runBlocking {
             val metadata = GHMetaData("", OperatingSystem.linux, Architecture.x64, "hotspot-jfr",
                 GHVersion(0, 1, 2, "", 4, "", 6, "", ""),
@@ -253,7 +252,7 @@ class AdoptBinaryMapperTest {
     }
 
     @Test
-    fun checkSumLinkFoundWhenChecksumIsSplitFromReleaseGroup() {
+    fun `checkSumLink found when checksum is split from release group`() {
         runBlocking {
             val asset = GHAsset(
                 "OpenJDK9-OPENJ9_ppc64le_Linux_jdk-9.0.4.12_openj9-0.9.0.tar.gz",
@@ -278,7 +277,7 @@ class AdoptBinaryMapperTest {
     }
 
     @Test
-    fun oldLargeHeapIsCorrectlyIdentified() {
+    fun `old large heap is correctly identified`() {
         runBlocking {
             val asset = GHAsset(
                 "OPENJ9_x64_LinuxLH_jdk8u181-b13_openj9-0.9.0.tar.gz",

--- a/adoptopenjdk-api-v3-updater/src/test/kotlin/net/adoptopenjdk/api/AdoptBinaryMapperTest.kt
+++ b/adoptopenjdk-api-v3-updater/src/test/kotlin/net/adoptopenjdk/api/AdoptBinaryMapperTest.kt
@@ -158,7 +158,7 @@ class AdoptBinaryMapperTest {
                         name = "archive.msi",
                         link = "http://installer-link",
                         size = 1,
-                        checksum = null, // NOTE: HTTP lookup for checksum currently fails, we could use real links to GitHub assets
+                        checksum = null, // NOTE: HTTP lookup for checksum currently fails, ideally we would use a test-double to fake the response
                         checksum_link = "http://installer-checksum-link",
                         download_count = 1,
                         signature_link = null,

--- a/adoptopenjdk-api-v3-updater/src/test/kotlin/net/adoptopenjdk/api/AdoptBinaryMapperTest.kt
+++ b/adoptopenjdk-api-v3-updater/src/test/kotlin/net/adoptopenjdk/api/AdoptBinaryMapperTest.kt
@@ -34,13 +34,15 @@ class AdoptBinaryMapperTest {
         "2013-02-27T19:35:32Z"
     )
 
-    val assets = listOf(jdk, GHAsset(
-        "OpenJDK8U-jdk_x64_linux_hotspot_2019-11-22-16-01.tar.gz",
-        1L,
-        "",
-        1L,
-        "2013-02-27T19:35:32Z"
-    )
+    val assets = listOf(
+        jdk,
+        GHAsset(
+            "OpenJDK8U-jdk_x64_linux_hotspot_2019-11-22-16-01.tar.gz",
+            1L,
+            "",
+            1L,
+            "2013-02-27T19:35:32Z"
+        )
     )
 
     @Test
@@ -63,7 +65,7 @@ class AdoptBinaryMapperTest {
             )
             val binaryList = AdoptBinaryMapper.toBinaryList(assets, assets, emptyMap())
 
-            assertEquals("a-download-link", binaryList.get(0).`package`.checksum_link)
+            assertEquals("a-download-link", binaryList[0].`package`.checksum_link)
         }
     }
 
@@ -80,10 +82,10 @@ class AdoptBinaryMapperTest {
             )
             val binaryList = AdoptBinaryMapper.toBinaryList(assets, assets, emptyMap())
 
-            assertEquals(JvmImpl.openj9, binaryList.get(0).jvm_impl)
-            assertEquals(Architecture.ppc64le, binaryList.get(0).architecture)
-            assertEquals(OperatingSystem.linux, binaryList.get(0).os)
-            assertEquals(Project.jdk, binaryList.get(0).project)
+            assertEquals(JvmImpl.openj9, binaryList[0].jvm_impl)
+            assertEquals(Architecture.ppc64le, binaryList[0].architecture)
+            assertEquals(OperatingSystem.linux, binaryList[0].os)
+            assertEquals(Project.jdk, binaryList[0].project)
         }
     }
 
@@ -99,7 +101,7 @@ class AdoptBinaryMapperTest {
     fun projectDefaultsToJdk() {
         runBlocking {
             val binaryList = AdoptBinaryMapper.toBinaryList(assets, assets, emptyMap())
-            assertEquals(Project.jdk, binaryList.get(1).project)
+            assertEquals(Project.jdk, binaryList[1].project)
         }
     }
 
@@ -140,7 +142,7 @@ class AdoptBinaryMapperTest {
 
             val binaryList = AdoptBinaryMapper.toBinaryList(listOf(asset), listOf(asset, checksum), emptyMap())
 
-            assertEquals("a-download-link", binaryList.get(0).`package`.checksum_link)
+            assertEquals("a-download-link", binaryList[0].`package`.checksum_link)
         }
     }
 
@@ -157,12 +159,37 @@ class AdoptBinaryMapperTest {
 
             val binaryList = AdoptBinaryMapper.toBinaryList(listOf(asset), listOf(asset), emptyMap())
 
-            assertEquals(HeapSize.large, binaryList.get(0).heap_size)
+            assertEquals(HeapSize.large, binaryList[0].heap_size)
+        }
+    }
+
+    @Test
+    fun createsMetadataLinkForPackage() {
+        runBlocking {
+            val assets = listOf(
+                GHAsset(
+                    "OpenJDK11U-jdk_x64_linux_hotspot_11.0.8_10.tar.gz",
+                    1L,
+                    "",
+                    1L,
+                    "2013-02-27T19:35:32Z"
+                ),
+                GHAsset(
+                    "OpenJDK11U-jdk_x64_linux_hotspot_11.0.8_10.tar.gz.json",
+                    1L,
+                    "a-download-link",
+                    1L,
+                    "2013-02-27T19:35:32Z"
+                )
+            )
+            val binaryList = AdoptBinaryMapper.toBinaryList(assets, assets, emptyMap())
+
+            assertEquals("a-download-link", binaryList[0].`package`.metadata_link)
         }
     }
 
     private fun assertParsedHotspotJfr(binaryList: List<Binary>) {
-        assertEquals(JvmImpl.hotspot, binaryList.get(0).jvm_impl)
-        assertEquals(Project.jfr, binaryList.get(0).project)
+        assertEquals(JvmImpl.hotspot, binaryList[0].jvm_impl)
+        assertEquals(Project.jfr, binaryList[0].project)
     }
 }

--- a/adoptopenjdk-api-v3-updater/src/test/kotlin/net/adoptopenjdk/api/AdoptReleaseMapperTest.kt
+++ b/adoptopenjdk-api-v3-updater/src/test/kotlin/net/adoptopenjdk/api/AdoptReleaseMapperTest.kt
@@ -28,19 +28,19 @@ import kotlin.test.assertNull
 class AdoptReleaseMapperTest : BaseTest() {
 
     val jdk = GHAsset(
-        "OpenJDK8U-jre_x64_linux_hotspot-123244354325.tar.gz",
-        1L,
-        "",
-        1L,
-        "2013-02-27T19:35:32Z"
+        name = "OpenJDK8U-jre_x64_linux_hotspot-123244354325.tar.gz",
+        size = 1L,
+        downloadUrl = "",
+        downloadCount = 1L,
+        updatedAt = "2013-02-27T19:35:32Z"
     )
 
     val checksum = GHAsset(
-        "OpenJDK8U-jre_x64_linux_hotspot-123244354325.tar.gz.sha256.txt",
-        1L,
-        "",
-        1L,
-        "2013-02-27T19:35:32Z"
+        name = "OpenJDK8U-jre_x64_linux_hotspot-123244354325.tar.gz.sha256.txt",
+        size = 1L,
+        downloadUrl = "",
+        downloadCount = 1L,
+        updatedAt = "2013-02-27T19:35:32Z"
     )
 
     @Test
@@ -48,7 +48,17 @@ class AdoptReleaseMapperTest : BaseTest() {
         runBlocking {
             val source = GHAssets(listOf(jdk), PageInfo(false, ""))
 
-            val ghRelease = GHRelease(GithubId("1"), "OpenJDK 123244354325", true, true, "2013-02-27T19:35:32Z", "2013-02-27T19:35:32Z", source, "8", "a-url")
+            val ghRelease = GHRelease(
+                id = GithubId("1"),
+                name = "OpenJDK 123244354325",
+                isPrerelease = true,
+                prerelease = true,
+                publishedAt = "2013-02-27T19:35:32Z",
+                updatedAt = "2013-02-27T19:35:32Z",
+                releaseAssets = source,
+                resourcePath = "8",
+                url = "a-url"
+            )
 
             val result = AdoptReleaseMapper.toAdoptRelease(ghRelease)
             assertFalse(result.succeeded())
@@ -63,7 +73,17 @@ class AdoptReleaseMapperTest : BaseTest() {
 
             val source = GHAssets(listOf(jdk, checksum), PageInfo(false, ""))
 
-            val ghRelease = GHRelease(GithubId("1"), "jdk9u-2018-09-27-08-50", true, true, "2013-02-27T19:35:32Z", "2013-02-27T19:35:32Z", source, "8", "https://github.com/AdoptOpenJDK/openjdk9-binaries/releases/download/jdk9u-2018-09-27-08-50/OpenJDK9U-jre_aarch64_linux_hotspot_2018-09-27-08-50.tar.gz")
+            val ghRelease = GHRelease(
+                id = GithubId("1"),
+                name = "jdk9u-2018-09-27-08-50",
+                isPrerelease = true,
+                prerelease = true,
+                publishedAt = "2013-02-27T19:35:32Z",
+                updatedAt = "2013-02-27T19:35:32Z",
+                releaseAssets = source,
+                resourcePath = "8",
+                url = "https://github.com/AdoptOpenJDK/openjdk9-binaries/releases/download/jdk9u-2018-09-27-08-50/OpenJDK9U-jre_aarch64_linux_hotspot_2018-09-27-08-50.tar.gz"
+            )
 
             val release = AdoptReleaseMapper.toAdoptRelease(ghRelease)
 
@@ -72,12 +92,22 @@ class AdoptReleaseMapperTest : BaseTest() {
     }
 
     @Test
-    fun obaysReleaseTypeforBinaryRepos() {
+    fun obeysReleaseTypeforBinaryRepos() {
         runBlocking {
 
             val source = GHAssets(listOf(jdk), PageInfo(false, ""))
 
-            val ghRelease = GHRelease(GithubId("1"), "jdk9u-2018-09-27-08-50", true, true, "2013-02-27T19:35:32Z", "2013-02-27T19:35:32Z", source, "8", "https://github.com/AdoptOpenJDK/openjdk9-binaries/releases/download/jdk9u-2018-09-27-08-50/OpenJDK9U-jre_aarch64_linux_hotspot_2018-09-27-08-50.tar.gz")
+            val ghRelease = GHRelease(
+                id = GithubId("1"),
+                name = "jdk9u-2018-09-27-08-50",
+                isPrerelease = true,
+                prerelease = true,
+                publishedAt = "2013-02-27T19:35:32Z",
+                updatedAt = "2013-02-27T19:35:32Z",
+                releaseAssets = source,
+                resourcePath = "8",
+                url = "https://github.com/AdoptOpenJDK/openjdk9-binaries/releases/download/jdk9u-2018-09-27-08-50/OpenJDK9U-jre_aarch64_linux_hotspot_2018-09-27-08-50.tar.gz"
+            )
 
             val release = AdoptReleaseMapper.toAdoptRelease(ghRelease)
 
@@ -182,7 +212,17 @@ class AdoptReleaseMapperTest : BaseTest() {
                 }
             }
 
-            val ghRelease = GHRelease(GithubId("1"), "jdk9u-2018-09-27-08-50", true, true, "2013-02-27T19:35:32Z", "2013-02-27T19:35:32Z", source, "8", "https://github.com/AdoptOpenJDK/openjdk9-binaries/releases/download/jdk9u-2018-09-27-08-50/OpenJDK9U-jre_aarch64_linux_hotspot_2018-09-27-08-50.tar.gz")
+            val ghRelease = GHRelease(
+                id = GithubId("1"),
+                name = "jdk9u-2018-09-27-08-50",
+                isPrerelease = true,
+                prerelease = true,
+                publishedAt = "2013-02-27T19:35:32Z",
+                updatedAt = "2013-02-27T19:35:32Z",
+                releaseAssets = source,
+                resourcePath = "8",
+                url = "https://github.com/AdoptOpenJDK/openjdk9-binaries/releases/download/jdk9u-2018-09-27-08-50/OpenJDK9U-jre_aarch64_linux_hotspot_2018-09-27-08-50.tar.gz"
+            )
 
             val release = AdoptReleaseMapper.toAdoptRelease(ghRelease)
 
@@ -215,7 +255,17 @@ class AdoptReleaseMapperTest : BaseTest() {
 
             val source = GHAssets(listOf(jdk), PageInfo(false, ""))
 
-            val ghRelease = GHRelease(GithubId("1"), "jdk9u-2018-09-27-08-50", true, true, "2013-02-27T19:35:32Z", "2013-02-27T19:35:32Z", source, "8", "https://github.com/AdoptOpenJDK/openjdk9-binaries/releases/download/jdk9u-2018-09-27-08-50/OpenJDK9U-jre_aarch64_linux_hotspot_2018-09-27-08-50.tar.gz")
+            val ghRelease = GHRelease(
+                id = GithubId("1"),
+                name = "jdk9u-2018-09-27-08-50",
+                isPrerelease = true,
+                prerelease = true,
+                publishedAt = "2013-02-27T19:35:32Z",
+                updatedAt = "2013-02-27T19:35:32Z",
+                releaseAssets = source,
+                resourcePath = "8",
+                url = "https://github.com/AdoptOpenJDK/openjdk9-binaries/releases/download/jdk9u-2018-09-27-08-50/OpenJDK9U-jre_aarch64_linux_hotspot_2018-09-27-08-50.tar.gz"
+            )
 
             val release = AdoptReleaseMapper.toAdoptRelease(ghRelease)
         }

--- a/adoptopenjdk-api-v3-updater/src/test/kotlin/net/adoptopenjdk/api/AdoptReposTest.kt
+++ b/adoptopenjdk-api-v3-updater/src/test/kotlin/net/adoptopenjdk/api/AdoptReposTest.kt
@@ -49,7 +49,8 @@ class AdoptReposTest : BaseTest() {
                                 "v",
                                 "c",
                                 3,
-                                "d"
+                                "d",
+                            "e"
                         ),
                         2L,
                         time,
@@ -59,7 +60,9 @@ class AdoptReposTest : BaseTest() {
                                 1L,
                                 "v",
                                 "c",
-                                4),
+                                4,
+                        "d",
+                        "e"),
                         HeapSize.normal,
                         OperatingSystem.linux,
                         Architecture.x64,

--- a/adoptopenjdk-api-v3-updater/src/test/kotlin/net/adoptopenjdk/api/StatsCalculatorTest.kt
+++ b/adoptopenjdk-api-v3-updater/src/test/kotlin/net/adoptopenjdk/api/StatsCalculatorTest.kt
@@ -57,11 +57,11 @@ class StatsCalculatorTest : BaseTest() {
                 time,
                 arrayOf(
                     Binary(
-                        Package("a", "b", 1L, "v", "c", 12L, "d"),
+                        Package("a", "b", 1L, "v", "c", 12L, "d", "e"),
                         15L, // Download count
                         time,
                         "d",
-                        Installer("a", "b", 1L, "v", "c", 3L),
+                        Installer("a", "b", 1L, "v", "c", 3L, "d", "e"),
                         HeapSize.normal,
                         OperatingSystem.linux,
                         Architecture.x64,
@@ -69,7 +69,7 @@ class StatsCalculatorTest : BaseTest() {
                         JvmImpl.hotspot,
                         Project.jdk
                     ), Binary(
-                        Package("a", "b", 1L, "v", "c", 250L, "d"),
+                        Package("a", "b", 1L, "v", "c", 250L, "d", "e"),
                         250L,
                         time,
                         "d",
@@ -81,7 +81,7 @@ class StatsCalculatorTest : BaseTest() {
                         JvmImpl.hotspot,
                         Project.jdk
                     ), Binary(
-                        Package("a", "b", 1L, "v", "c", 60L, "d"),
+                        Package("a", "b", 1L, "v", "c", 60L, "d", "e"),
                         60L,
                         time,
                         "d",
@@ -93,7 +93,7 @@ class StatsCalculatorTest : BaseTest() {
                         JvmImpl.openj9,
                         Project.jdk
                     ), Binary(
-                        Package("a", "b", 1L, "v", "c", 120L, "d"),
+                        Package("a", "b", 1L, "v", "c", 120L, "d", "e"),
                         120L,
                         time,
                         "d",
@@ -118,11 +118,11 @@ class StatsCalculatorTest : BaseTest() {
                 time,
                 arrayOf(
                     Binary(
-                        Package("a", "b", 1L, "v", "c", 300L, "d"),
+                        Package("a", "b", 1L, "v", "c", 300L, "d", "e"),
                         300L, // Download count
                         time,
                         "d",
-                        Installer("a", "b", 1L, "v", "c", 3L),
+                        Installer("a", "b", 1L, "v", "c", 3L, "d", "e"),
                         HeapSize.normal,
                         OperatingSystem.linux,
                         Architecture.x64,
@@ -130,7 +130,7 @@ class StatsCalculatorTest : BaseTest() {
                         JvmImpl.hotspot,
                         Project.jdk
                     ), Binary(
-                        Package("a", "b", 1L, "v", "c", 150L, "d"),
+                        Package("a", "b", 1L, "v", "c", 150L, "d", "e"),
                         150L,
                         time,
                         "d",


### PR DESCRIPTION
Identifies `.json` assets for an archive (.tar.gz, .zip) and exposes against the Package as a metadata_link.

Fixes #235 and #236 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

# Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] You added tests to cover the change
- [x] `mvn clean install` build and test completes