### PR TITLE
ADR2 Branching & release strategy contributing guide updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,11 +13,11 @@ There are two main branches in the project:
 - `master`
 - `production`
 
+All contributions should be made by forking the project and raising a pull request (PR) against the `master` branch.
+
 The `master` branch represents the current live state of the [Staging environment](https://staging-api.adoptopenjdk.net/).
 
 The `production` branch represents the current live state of the [Production environment](https://api.adoptopenjdk.net/).
-
-All contributions should be made by forking the project and raising a pull request (PR) against the `master` branch.
 
 For more details related to deployment of the API, see [the deployment section](#deployment--continuous-deployment-cd) of this guide.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,8 @@ The `production` branch represents the current live state of the production Open
 
 All contributions should be made by forking the project and raising a pull request (PR) against the `master` branch.
 
+For more details related to deployment of the API, see [the deployment section](#deployment--continuous-deployment-cd) of this guide.
+
 ## Build
 
 ### Pre-Requisites

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,12 +18,6 @@ The `production` branch represents the current live state of the production Open
 
 All contributions should be made by forking the project and raising a pull request (PR) against the `master` branch.
 
-### Production releases & deployment
-
-The `production` branch is synchronised with `master` to perform a release of the latest API changes to the production OpenShift environment.  
-
-This is done via a PR that applies all outstanding commits from `master` to `production`. 
-
 ## Build
 
 ### Pre-Requisites
@@ -124,10 +118,14 @@ You can choose to deploy this API where you wish, for AdoptOpenJDK we use Contin
 
 ### AdoptOpenJDK
 
-For AdoptOpenJDK, this API deploys to Red Hat OpenShift and is front ended by [Cloudflare](https://www.cloudflare.com) as a CDN
+For AdoptOpenJDK, this API deploys to Red Hat OpenShift and is front ended by [Cloudflare](https://www.cloudflare.com) as a CDN.
+
+The `production` branch is synchronised with `master` to perform a release of the latest API changes to the Production OpenShift environment.  
+
+This is done via a pull request that applies all outstanding commits from `master` to `production`.
 
 The Jenkins [AdoptOpenJDK CI Server](https://ci.adoptopenjdk.net) will automatically 
-deploy Pull Requests to the OpenShift Staging (the `master` branch) or Production (the `production` branch.) environments.
+deploy pull requests to the OpenShift Staging (the `master` branch) or Production (the `production` branch) environments.
 
 ## Code Architecture and Code
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,13 +7,22 @@ calls via the GitHub API in order to retrieve AdoptOpenJDK binaries and metadata
 
 Since the GitHub API is rate limited we use MongoDB as a caching mechanism.
 
-## Source code management and branching
+## Source code management & branching
 
-We treat the AdoptOpenJDK org repository as the canonical repository for deploying the API from. 
-We use the `staging` branch to trial any changes in a Production like environment and then 
-eventually merge into `master` for a real Production deployment.
+There are two main branches in the project:
+- `master`
+- `production`
 
-**NOTE** Please ensure for any significant change that you Pull Request to the `staging` branch 
+The `master` branch represents the current live state of the staging OpenShift environment.
+The `production` branch represents the current live state of the production OpenShift environment.
+
+All contributions should be made by forking the project and raising a pull request (PR) against the `master` branch.
+
+### Production releases & deployment
+
+The `production` branch is synchronised with `master` to perform a release of the latest API changes to the production OpenShift environment.  
+
+This is done via a PR that applies all outstanding commits from `master` to `production`. 
 
 ## Build
 
@@ -115,10 +124,10 @@ You can choose to deploy this API where you wish, for AdoptOpenJDK we use Contin
 
 ### AdoptOpenJDK
 
-For AdoptOpenJDK, this API deploys to Red Hat OpenShift and is front ended by Cloud Flare as a CDN
+For AdoptOpenJDK, this API deploys to Red Hat OpenShift and is front ended by [Cloudflare](https://www.cloudflare.com) as a CDN
 
 The Jenkins [AdoptOpenJDK CI Server](https://ci.adoptopenjdk.net) will automatically 
-deploy Pull Requests to OpenShift to Staging (the `staging` branch) or Production (the `master` branch.)
+deploy Pull Requests to the OpenShift Staging (the `master` branch) or Production (the `production` branch.) environments.
 
 ## Code Architecture and Code
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,8 +13,9 @@ There are two main branches in the project:
 - `master`
 - `production`
 
-The `master` branch represents the current live state of the staging OpenShift environment.
-The `production` branch represents the current live state of the production OpenShift environment.
+The `master` branch represents the current live state of the [Staging environment](https://staging-api.adoptopenjdk.net/).
+
+The `production` branch represents the current live state of the [Production environment](https://api.adoptopenjdk.net/).
 
 All contributions should be made by forking the project and raising a pull request (PR) against the `master` branch.
 


### PR DESCRIPTION
Updates to the CONTRIBUTING.md guide based on [ADR2](https://github.com/AdoptOpenJDK/openjdk-api-v3/blob/master/docs/adr/0002-branching-and-release-strategy.md) and #284. 

Merging of this PR should be coordinated with the changes to the branches and OpenShift deployment strategy.

# Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] You changed or added to the documentation