### PR TITLE
Possible Solution to java patch version issue

### DIFF
--- a/adoptopenjdk-api-v3-frontend/src/main/kotlin/net/adoptopenjdk/api/v3/OpenApiDocs.kt
+++ b/adoptopenjdk-api-v3-frontend/src/main/kotlin/net/adoptopenjdk/api/v3/OpenApiDocs.kt
@@ -30,8 +30,8 @@ object OpenApiDocs {
 
     const val VERSION_RANGE =
         """
-<p>Semantic version range (maven style) of versions to include.</p>
-<p>e.g: <code><ul><li>11.0.4+11.1</li><li>[1.0,2.0)</li><li>(,1.0]</li></ul></code></p>
+<p>Java version range (maven style) of versions to include.</p>
+<p>e.g: <code><ul><li>11.0.4.1+11.1</li><li>[1.0,2.0)</li><li>(,1.0]</li></ul></code></p>
 <p>Details of maven version ranges can be found at 
     <a href="https://maven.apache.org/enforcer/enforcer-rules/versionRanges.html">https://maven.apache.org/enforcer/enforcer-rules/versionRanges.html<a>.
 </p>

--- a/adoptopenjdk-api-v3-frontend/src/main/kotlin/net/adoptopenjdk/api/v3/routes/packages/PackageEndpoint.kt
+++ b/adoptopenjdk-api-v3-frontend/src/main/kotlin/net/adoptopenjdk/api/v3/routes/packages/PackageEndpoint.kt
@@ -4,7 +4,7 @@ import net.adoptopenjdk.api.v3.JsonMapper
 import net.adoptopenjdk.api.v3.dataSources.APIDataStore
 import net.adoptopenjdk.api.v3.dataSources.SortMethod
 import net.adoptopenjdk.api.v3.dataSources.SortOrder
-import net.adoptopenjdk.api.v3.dataSources.models.Releases.Companion.VERSION_COMPARATOR
+import net.adoptopenjdk.api.v3.dataSources.models.Releases.Companion.RELEASE_COMPARATOR
 import net.adoptopenjdk.api.v3.filters.BinaryFilter
 import net.adoptopenjdk.api.v3.filters.ReleaseFilter
 import net.adoptopenjdk.api.v3.models.APIError
@@ -86,7 +86,7 @@ open class PackageEndpoint {
         val releases = APIDataStore.getAdoptRepos().getFilteredReleases(releaseFilter, binaryFilter, SortOrder.DESC, SortMethod.DEFAULT).toList()
 
         // We use updated_at and timestamp as well JIC we've made a mistake and respun the same version number twice, in which case newest wins.
-        val comparator = VERSION_COMPARATOR.thenBy { it.version_data.optional }
+        val comparator = RELEASE_COMPARATOR.thenBy { it.version_data.optional }
             .thenBy { it.updated_at }
             .thenBy { it.timestamp }
 

--- a/adoptopenjdk-api-v3-frontend/src/test/kotlin/net/adoptopenjdk/api/AssetsResourceFeatureReleasePathTest.kt
+++ b/adoptopenjdk-api-v3-frontend/src/test/kotlin/net/adoptopenjdk/api/AssetsResourceFeatureReleasePathTest.kt
@@ -65,7 +65,7 @@ class AssetsResourceFeatureReleasePathTest : AssetsPathTest() {
                 null,
                 { previous: Release?, next: Release ->
                     if (previous != null) {
-                        if (Releases.VERSION_COMPARATOR.compare(previous, next) > 0) {
+                        if (Releases.RELEASE_COMPARATOR.compare(previous, next) > 0) {
                             fail("${previous.version_data} is before ${next.version_data}")
                         }
                     }
@@ -81,7 +81,7 @@ class AssetsResourceFeatureReleasePathTest : AssetsPathTest() {
                 null,
                 { previous: Release?, next: Release ->
                     if (previous != null) {
-                        if (Releases.VERSION_COMPARATOR.compare(previous, next) < 0) {
+                        if (Releases.RELEASE_COMPARATOR.compare(previous, next) < 0) {
                             fail("${previous.version_data} is before ${next.version_data}")
                         }
                     }

--- a/adoptopenjdk-api-v3-models/pom.xml
+++ b/adoptopenjdk-api-v3-models/pom.xml
@@ -26,10 +26,6 @@
             <artifactId>microprofile-openapi-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-artifact</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/adoptopenjdk-api-v3-models/src/main/kotlin/net/adoptopenjdk/api/v3/models/Binary.kt
+++ b/adoptopenjdk-api-v3-models/src/main/kotlin/net/adoptopenjdk/api/v3/models/Binary.kt
@@ -90,7 +90,7 @@ class Binary {
         result = 31 * result + architecture.hashCode()
         result = 31 * result + image_type.hashCode()
         result = 31 * result + jvm_impl.hashCode()
-        result = 31 * result + (`package`?.hashCode() ?: 0)
+        result = 31 * result + `package`.hashCode()
         result = 31 * result + (installer?.hashCode() ?: 0)
         result = 31 * result + heap_size.hashCode()
         result = 31 * result + download_count.hashCode()

--- a/adoptopenjdk-api-v3-models/src/main/kotlin/net/adoptopenjdk/api/v3/models/VersionData.kt
+++ b/adoptopenjdk-api-v3-models/src/main/kotlin/net/adoptopenjdk/api/v3/models/VersionData.kt
@@ -53,6 +53,8 @@ class VersionData : Comparable<VersionData> {
         }
 
         var metadata = listOf<String>()
+
+        // 100 to match the same change made in the build repo
         val buildOffset = if (patch != null && patch != 0) patch * 100 else 0
 
         if (build != 0) {

--- a/adoptopenjdk-api-v3-models/src/main/kotlin/net/adoptopenjdk/api/v3/models/VersionData.kt
+++ b/adoptopenjdk-api-v3-models/src/main/kotlin/net/adoptopenjdk/api/v3/models/VersionData.kt
@@ -1,5 +1,6 @@
 package net.adoptopenjdk.api.v3.models
 
+import net.adoptopenjdk.api.v3.dataSources.models.Releases
 import org.eclipse.microprofile.openapi.annotations.media.Schema
 
 class VersionData : Comparable<VersionData> {
@@ -7,6 +8,7 @@ class VersionData : Comparable<VersionData> {
     val major: Int
     val minor: Int
     val security: Int
+    val patch: Int?
     val pre: String?
     val adopt_build_number: Int?
 
@@ -27,11 +29,13 @@ class VersionData : Comparable<VersionData> {
         build: Int,
         optional: String?,
         openjdk_version: String,
-        semver: String? = null
+        semver: String? = null,
+        patch: Int? = null
     ) {
         this.major = major
         this.minor = minor
         this.security = security
+        this.patch = patch
         this.pre = if (pre?.isNotEmpty() == true) pre else null
         this.adopt_build_number = if (adopt_build_number != null && adopt_build_number != 0) adopt_build_number else null
         this.build = build
@@ -45,12 +49,14 @@ class VersionData : Comparable<VersionData> {
         var semver = major.toString() + "." + minor + "." + security
 
         if (pre?.isNotEmpty() == true) {
-            semver += "-" + pre
+            semver += "-$pre"
         }
 
         var metadata = listOf<String>()
+        val buildOffset = if (patch != null && patch != 0) patch * 100 else 0
+
         if (build != 0) {
-            metadata = metadata.plus(build.toString())
+            metadata = metadata.plus((buildOffset + build).toString())
         }
 
         if (adopt_build_number != null && adopt_build_number != 0) {
@@ -72,9 +78,9 @@ class VersionData : Comparable<VersionData> {
         var result = major
         result = 31 * result + minor
         result = 31 * result + security
+        result = 31 * result + (patch?.hashCode() ?: 0)
         result = 31 * result + (pre?.hashCode() ?: 0)
         result = 31 * result + (adopt_build_number ?: 0)
-        result = 31 * result + (semver?.hashCode() ?: 0)
         result = 31 * result + openjdk_version.hashCode()
         result = 31 * result + build
         result = 31 * result + (optional?.hashCode() ?: 0)
@@ -87,16 +93,25 @@ class VersionData : Comparable<VersionData> {
 
         other as VersionData
 
+        if (openjdk_version != other.openjdk_version) return false
+
+        return compareVersionNumber(other)
+    }
+
+    fun compareVersionNumber(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as VersionData
+
         if (major != other.major) return false
         if (minor != other.minor) return false
         if (security != other.security) return false
+        if (patch != other.patch) return false
         if (pre != other.pre) return false
-        if (adopt_build_number != other.adopt_build_number) return false
-        if (semver != other.semver) return false
-        if (openjdk_version != other.openjdk_version) return false
         if (build != other.build) return false
         if (optional != other.optional) return false
-
+        if (adopt_build_number != other.adopt_build_number) return false
         return true
     }
 
@@ -108,7 +123,8 @@ class VersionData : Comparable<VersionData> {
         val COMPARATOR = compareBy<VersionData> { it.major }
             .thenBy { it.minor }
             .thenBy { it.security }
-            .thenBy { it.pre }
+            .thenBy { it.patch }
+            .then(Releases.PRE_SORTER)
             .thenBy { it.build }
             .thenBy { it.adopt_build_number }
             .thenBy { it.optional }

--- a/adoptopenjdk-api-v3-models/src/main/kotlin/net/adoptopenjdk/api/v3/parser/maven/InvalidVersionSpecificationException.kt
+++ b/adoptopenjdk-api-v3-models/src/main/kotlin/net/adoptopenjdk/api/v3/parser/maven/InvalidVersionSpecificationException.kt
@@ -1,0 +1,28 @@
+package net.adoptopenjdk.api.v3.parser.maven
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Based on work from the org.apache.maven:maven-artifact project
+ */ /**
+ * Occurs when a version is invalid.
+ *
+ * @author [Brett Porter](mailto:brett@apache.org)
+ */
+class InvalidVersionSpecificationException(message: String?) : Exception(message)

--- a/adoptopenjdk-api-v3-models/src/main/kotlin/net/adoptopenjdk/api/v3/parser/maven/Restriction.kt
+++ b/adoptopenjdk-api-v3-models/src/main/kotlin/net/adoptopenjdk/api/v3/parser/maven/Restriction.kt
@@ -1,0 +1,114 @@
+package net.adoptopenjdk.api.v3.parser.maven
+
+import net.adoptopenjdk.api.v3.models.VersionData
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Based on work from the org.apache.maven:maven-artifact project
+ */
+
+/**
+ * Describes a restriction in versioning.
+ *
+ * @author [Brett Porter](mailto:brett@apache.org)
+ */
+class Restriction(
+    val lowerBound: VersionData?,
+    val isLowerBoundInclusive: Boolean,
+    val upperBound: VersionData?,
+    val isUpperBoundInclusive: Boolean
+) {
+    fun containsVersion(version: VersionData?): Boolean {
+        if (lowerBound != null) {
+            val comparison = lowerBound.compareTo(version!!)
+            if (comparison == 0 && !isLowerBoundInclusive) {
+                return false
+            }
+            if (comparison > 0) {
+                return false
+            }
+        }
+        if (upperBound != null) {
+            val comparison = upperBound.compareTo(version!!)
+            if (comparison == 0 && !isUpperBoundInclusive) {
+                return false
+            }
+            if (comparison < 0) {
+                return false
+            }
+        }
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = 13
+        result += lowerBound?.hashCode() ?: 1
+        result *= if (isLowerBoundInclusive) 1 else 2
+        result -= upperBound?.hashCode() ?: 3
+        result *= if (isUpperBoundInclusive) 2 else 3
+        return result
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) {
+            return true
+        }
+        if (other !is Restriction) {
+            return false
+        }
+        if (lowerBound != null) {
+            if (lowerBound != other.lowerBound) {
+                return false
+            }
+        } else if (other.lowerBound != null) {
+            return false
+        }
+        if (isLowerBoundInclusive != other.isLowerBoundInclusive) {
+            return false
+        }
+        if (upperBound != null) {
+            if (upperBound != other.upperBound) {
+                return false
+            }
+        } else if (other.upperBound != null) {
+            return false
+        }
+        return isUpperBoundInclusive == other.isUpperBoundInclusive
+    }
+
+    override fun toString(): String {
+        val buf = StringBuilder()
+        buf.append(if (isLowerBoundInclusive) '[' else '(')
+        if (lowerBound != null) {
+            buf.append(lowerBound.toString())
+        }
+        buf.append(',')
+        if (upperBound != null) {
+            buf.append(upperBound.toString())
+        }
+        buf.append(if (isUpperBoundInclusive) ']' else ')')
+        return buf.toString()
+    }
+
+    companion object {
+        val EVERYTHING = Restriction(null, false, null, false)
+    }
+}

--- a/adoptopenjdk-api-v3-models/src/main/kotlin/net/adoptopenjdk/api/v3/parser/maven/VersionRange.kt
+++ b/adoptopenjdk-api-v3-models/src/main/kotlin/net/adoptopenjdk/api/v3/parser/maven/VersionRange.kt
@@ -1,0 +1,179 @@
+package net.adoptopenjdk.api.v3.parser.maven
+
+import net.adoptopenjdk.api.v3.models.VersionData
+import net.adoptopenjdk.api.v3.parser.VersionParser.parse
+import java.util.*
+
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*  http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+/*
+ * Based on work from the org.apache.maven:maven-artifact project
+ */
+
+/**
+ * Construct a version range from a specification.
+ *
+ * @author [Brett Porter](mailto:brett@apache.org)
+ */
+class VersionRange private constructor(
+    val recommendedVersion: VersionData?,
+    val restrictions: List<Restriction>?
+) {
+
+    fun containsVersion(version: VersionData?): Boolean {
+        for (restriction in restrictions!!) {
+            if (restriction.containsVersion(version)) {
+                return true
+            }
+        }
+        return false
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) {
+            return true
+        }
+        if (other !is VersionRange) {
+            return false
+        }
+        return (recommendedVersion == other.recommendedVersion && restrictions == other.restrictions)
+    }
+
+    override fun hashCode(): Int {
+        var hash = 7
+        hash = 31 * hash + (recommendedVersion?.hashCode() ?: 0)
+        hash = 31 * hash + (restrictions?.hashCode() ?: 0)
+        return hash
+    }
+
+    companion object {
+        private val CACHE_SPEC = Collections.synchronizedMap(WeakHashMap<String, VersionRange>())
+
+        /**
+         *
+         *
+         * Create a version range from a string representation
+         *
+         * Some spec examples are:
+         *
+         *  * `1.0` Version 1.0
+         *  * `[1.0,2.0)` Versions 1.0 (included) to 2.0 (not included)
+         *  * `[1.0,2.0]` Versions 1.0 to 2.0 (both included)
+         *  * `[1.5,)` Versions 1.5 and higher
+         *  * `(,1.0],[1.2,)` Versions up to 1.0 (included) and 1.2 or higher
+         *
+         *
+         * @param spec string representation of a version or version range
+         * @return a new [VersionRange] object that represents the spec
+         * @throws InvalidVersionSpecificationException
+         */
+        @Throws(InvalidVersionSpecificationException::class)
+        fun createFromVersionSpec(spec: String?): VersionRange? {
+            if (spec == null) {
+                return null
+            }
+            var cached = CACHE_SPEC[spec]
+            if (cached != null) {
+                return cached
+            }
+            val restrictions: MutableList<Restriction> = ArrayList()
+            var process: String = spec
+            var version: VersionData? = null
+            var upperBound: VersionData? = null
+            var lowerBound: VersionData? = null
+            while (process.startsWith("[") || process.startsWith("(")) {
+                val index1 = process.indexOf(')')
+                val index2 = process.indexOf(']')
+                var index = index2
+                if (index2 < 0 || index1 < index2) {
+                    if (index1 >= 0) {
+                        index = index1
+                    }
+                }
+                if (index < 0) {
+                    throw InvalidVersionSpecificationException("Unbounded range: $spec")
+                }
+                val restriction = parseRestriction(process.substring(0, index + 1))
+                if (lowerBound == null) {
+                    lowerBound = restriction.lowerBound
+                }
+                if (upperBound != null) {
+                    if (restriction.lowerBound == null || restriction.lowerBound < upperBound) {
+                        throw InvalidVersionSpecificationException("Ranges overlap: $spec")
+                    }
+                }
+                restrictions.add(restriction)
+                upperBound = restriction.upperBound
+                process = process.substring(index + 1).trim { it <= ' ' }
+                if (process.isNotEmpty() && process.startsWith(",")) {
+                    process = process.substring(1).trim { it <= ' ' }
+                }
+            }
+            if (process.isNotEmpty()) {
+                if (restrictions.size > 0) {
+                    throw InvalidVersionSpecificationException(
+                        "Only fully-qualified sets allowed in multiple set scenario: $spec"
+                    )
+                } else {
+                    version = parse(process, false, true)
+                    restrictions.add(Restriction.EVERYTHING)
+                }
+            }
+            cached = VersionRange(version, restrictions)
+            CACHE_SPEC[spec] = cached
+            return cached
+        }
+
+        @Throws(InvalidVersionSpecificationException::class)
+        private fun parseRestriction(spec: String): Restriction {
+            val lowerBoundInclusive = spec.startsWith("[")
+            val upperBoundInclusive = spec.endsWith("]")
+            val process = spec.substring(1, spec.length - 1).trim { it <= ' ' }
+            val restriction: Restriction
+            val index = process.indexOf(',')
+            if (index < 0) {
+                if (!lowerBoundInclusive || !upperBoundInclusive) {
+                    throw InvalidVersionSpecificationException("Single version must be surrounded by []: $spec")
+                }
+                val version: VersionData = parse(process, false, true)
+                restriction = Restriction(version, lowerBoundInclusive, version, upperBoundInclusive)
+            } else {
+                val lowerBound = process.substring(0, index).trim { it <= ' ' }
+                val upperBound = process.substring(index + 1).trim { it <= ' ' }
+                if (lowerBound == upperBound) {
+                    throw InvalidVersionSpecificationException("Range cannot have identical boundaries: $spec")
+                }
+                var lowerVersion: VersionData? = null
+                if (lowerBound.isNotEmpty()) {
+                    lowerVersion = parse(lowerBound, false, true)
+                }
+                var upperVersion: VersionData? = null
+                if (upperBound.isNotEmpty()) {
+                    upperVersion = parse(upperBound, false, true)
+                }
+                if (upperVersion != null && lowerVersion != null && upperVersion < lowerVersion) {
+                    throw InvalidVersionSpecificationException("Range defies version ordering: $spec")
+                }
+                restriction = Restriction(lowerVersion, lowerBoundInclusive, upperVersion, upperBoundInclusive)
+            }
+            return restriction
+        }
+    }
+}

--- a/adoptopenjdk-api-v3-models/src/test/kotlin/net/adoptopenjdk/api/VersionParserTest.kt
+++ b/adoptopenjdk-api-v3-models/src/test/kotlin/net/adoptopenjdk/api/VersionParserTest.kt
@@ -1,18 +1,20 @@
 package net.adoptopenjdk.api
 
-import java.net.URLDecoder
-import java.nio.charset.Charset
 /* ktlint-disable no-wildcard-imports */
-import java.util.*
 /* ktlint-enable no-wildcard-imports */
-import java.util.stream.Stream
+import net.adoptopenjdk.api.v3.dataSources.models.Releases
 import net.adoptopenjdk.api.v3.models.VersionData
 import net.adoptopenjdk.api.v3.parser.VersionParser
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DynamicTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestFactory
+import java.net.URLDecoder
+import java.nio.charset.Charset
+import java.util.*
+import java.util.stream.Stream
 
 class VersionParserTest {
 
@@ -119,6 +121,47 @@ class VersionParserTest {
             )
         )
     )
+
+    @Test
+    fun `adopt semver works with java patch verstion`() {
+        val parsed = VersionParser.parse("11.0.9.1+1")
+        assertEquals(
+            VersionData(11, 0, 9, null, null, 1, null, "11.0.9.1+1", "11.0.9+101", 1),
+            parsed
+        )
+
+        assertEquals("11.0.9+101", parsed.formSemver())
+    }
+
+    @Test
+    fun `patch versions sort correctly`() {
+        val sorted = listOf(
+            VersionData(11, 0, 7, null, null, 9, null, "11.0.7.2+9", "11.0.7+209", 2),
+            VersionData(11, 0, 7, null, null, 9, null, "11.0.7+9", "11.0.7+9"),
+            VersionData(11, 0, 7, null, null, 9, null, "11.0.7.1+9", "11.0.7+109", 1),
+            VersionData(11, 0, 8, null, null, 9, null, "11.0.8+9", "11.0.8+9")
+        )
+            .sortedWith(Releases.VERSION_COMPARATOR)
+
+        assertNull(sorted.get(0).patch)
+        assertEquals(1, sorted.get(1).patch)
+        assertEquals(2, sorted.get(2).patch)
+        assertEquals(8, sorted.get(3).security)
+    }
+
+    @Test
+    fun `null pre comes after non null`() {
+        val sorted = listOf(
+            VersionData(11, 0, 7, "2", null, 9, null, "11.0.7-ea+9"),
+            VersionData(11, 0, 7, "1", null, 9, null, "11.0.7-ea+9"),
+            VersionData(11, 0, 7, null, null, 9, null, "11.0.7-ea+9")
+        )
+            .sortedWith(Releases.VERSION_COMPARATOR)
+
+        assertEquals("1", sorted.get(0).pre)
+        assertEquals("2", sorted.get(1).pre)
+        assertNull(sorted.get(2).pre)
+    }
 
     @TestFactory
     fun parsesVersionsCorrectly(): Stream<DynamicTest> {

--- a/adoptopenjdk-api-v3-models/src/test/kotlin/net/adoptopenjdk/api/VersionParserTest.kt
+++ b/adoptopenjdk-api-v3-models/src/test/kotlin/net/adoptopenjdk/api/VersionParserTest.kt
@@ -123,7 +123,7 @@ class VersionParserTest {
     )
 
     @Test
-    fun `adopt semver works with java patch verstion`() {
+    fun `adopt semver works with java patch version`() {
         val parsed = VersionParser.parse("11.0.9.1+1")
         assertEquals(
             VersionData(11, 0, 9, null, null, 1, null, "11.0.9.1+1", "11.0.9+101", 1),

--- a/adoptopenjdk-api-v3-models/src/test/kotlin/net/adoptopenjdk/api/VersionParserTest.kt
+++ b/adoptopenjdk-api-v3-models/src/test/kotlin/net/adoptopenjdk/api/VersionParserTest.kt
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestFactory
 import java.net.URLDecoder
 import java.nio.charset.Charset
-import java.util.*
+import java.util.TreeSet
 import java.util.stream.Stream
 
 class VersionParserTest {

--- a/adoptopenjdk-api-v3-models/src/test/kotlin/net/adoptopenjdk/api/VersionRangeTest.kt
+++ b/adoptopenjdk-api-v3-models/src/test/kotlin/net/adoptopenjdk/api/VersionRangeTest.kt
@@ -1,0 +1,69 @@
+package net.adoptopenjdk.api
+
+import net.adoptopenjdk.api.v3.models.VersionData
+import net.adoptopenjdk.api.v3.parser.maven.VersionRange
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class VersionRangeTest {
+
+    private val noPatch = VersionData(11, 0, 1, null, null, 4, null, "11.0.1+4", null, null)
+    private val patch1 = VersionData(11, 0, 1, null, null, 4, null, "11.0.1.1+4", null, 1)
+    private val patch2 = VersionData(11, 0, 1, null, null, 4, null, "11.0.1.2+4", null, 2)
+    private val nextBuild = VersionData(11, 0, 2, null, null, 5, null, "11.0.2+5", null, 1)
+
+    @Test
+    fun `filters correctly`() {
+        val range = VersionRange.createFromVersionSpec("[11.0.1.1,)")!!
+        assertFalse(range.containsVersion(noPatch))
+        assertTrue(range.containsVersion(patch1))
+        assertTrue(range.containsVersion(patch2))
+        assertTrue(range.containsVersion(nextBuild))
+    }
+
+    @Test
+    fun `filters correctly 2`() {
+        val range = VersionRange.createFromVersionSpec("(,11.0.1.1+4)")!!
+        assertTrue(range.containsVersion(noPatch))
+        assertFalse(range.containsVersion(patch1))
+        assertFalse(range.containsVersion(patch2))
+        assertFalse(range.containsVersion(nextBuild))
+    }
+
+    @Test
+    fun `filters correctly 3`() {
+        val range = VersionRange.createFromVersionSpec("(,11.0.1.1+4]")!!
+        assertTrue(range.containsVersion(noPatch))
+        assertTrue(range.containsVersion(patch1))
+        assertFalse(range.containsVersion(patch2))
+        assertFalse(range.containsVersion(nextBuild))
+    }
+
+    @Test
+    fun `filters correctly 4`() {
+        val range = VersionRange.createFromVersionSpec("(,11.0.1.2+1]")!!
+        assertTrue(range.containsVersion(noPatch))
+        assertTrue(range.containsVersion(patch1))
+        assertFalse(range.containsVersion(patch2))
+        assertFalse(range.containsVersion(nextBuild))
+    }
+
+    @Test
+    fun `filters correctly 5`() {
+        val range = VersionRange.createFromVersionSpec("[11.0.1+4,11.0.2+5)")!!
+        assertTrue(range.containsVersion(noPatch))
+        assertTrue(range.containsVersion(patch1))
+        assertTrue(range.containsVersion(patch2))
+        assertFalse(range.containsVersion(nextBuild))
+    }
+
+    @Test
+    fun `filters correctly 6`() {
+        val range = VersionRange.createFromVersionSpec("[11.0.2+4,)")!!
+        assertFalse(range.containsVersion(noPatch))
+        assertFalse(range.containsVersion(patch1))
+        assertFalse(range.containsVersion(patch2))
+        assertTrue(range.containsVersion(nextBuild))
+    }
+}

--- a/adoptopenjdk-api-v3-updater/src/main/kotlin/net/adoptopenjdk/api/v3/dataSources/github/graphql/models/GHMetaData.kt
+++ b/adoptopenjdk-api-v3-updater/src/main/kotlin/net/adoptopenjdk/api/v3/dataSources/github/graphql/models/GHMetaData.kt
@@ -18,10 +18,11 @@ data class GHVersion @JsonCreator constructor(
     @JsonProperty("version") val version: String,
     @JsonProperty("build") val build: Int,
     @JsonProperty("opt") val opt: String?,
-    @JsonProperty("semver") val semver: String?
+    @JsonProperty("semver") val semver: String?,
+    @JsonProperty("patch") val patch: Int? = null
 ) {
     fun toApiVersion(): VersionData {
-        return VersionData(major, minor, security, pre, adopt_build_number, build, opt, version, semver)
+        return VersionData(major, minor, security, pre, adopt_build_number, build, opt, version, semver, patch)
     }
 }
 

--- a/adoptopenjdk-api-v3-updater/src/test/kotlin/net/adoptopenjdk/api/AdoptBinaryMapperTest.kt
+++ b/adoptopenjdk-api-v3-updater/src/test/kotlin/net/adoptopenjdk/api/AdoptBinaryMapperTest.kt
@@ -93,7 +93,7 @@ class AdoptBinaryMapperTest {
                 os = OperatingSystem.mac,
                 arch = Architecture.x64,
                 variant = "hotspot",
-                version = GHVersion(0, 1, 2, "", 4, "", 6, "", ""),
+                version = GHVersion(0, 1, 2, "", 4, "", 6, "", "", null),
                 scmRef = "scm-ref",
                 version_data = "",
                 binary_type = ImageType.jdk,
@@ -129,7 +129,7 @@ class AdoptBinaryMapperTest {
                 os = OperatingSystem.mac,
                 arch = Architecture.x64,
                 variant = "hotspot",
-                version = GHVersion(0, 1, 2, "", 4, "", 6, "", ""),
+                version = GHVersion(0, 1, 2, "", 4, "", 6, "", "", null),
                 scmRef = "",
                 version_data = "",
                 binary_type = ImageType.jdk,
@@ -260,7 +260,7 @@ class AdoptBinaryMapperTest {
         runBlocking {
             val metadata = GHMetaData(
                 "", OperatingSystem.linux, Architecture.x64, "hotspot-jfr",
-                GHVersion(0, 1, 2, "", 4, "", 6, "", ""),
+                GHVersion(0, 1, 2, "", 4, "", 6, "", "", null),
                 "",
                 "",
                 ImageType.jdk,

--- a/pom.xml
+++ b/pom.xml
@@ -112,11 +112,6 @@
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.maven</groupId>
-                <artifactId>maven-artifact</artifactId>
-                <version>3.6.3</version>
-            </dependency>
-            <dependency>
                 <groupId>org.eclipse.microprofile.openapi</groupId>
                 <artifactId>microprofile-openapi-api</artifactId>
                 <version>1.1.2</version>


### PR DESCRIPTION
This changes our filter ranges from accepting a semver into taking a java version, this change should be backwards compatible.
This involved bringing in the version range filter from maven and customising it for our versions.

# Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] You added tests to cover the change
- [ ] `mvn clean install` build and test completes
- [ ] You changed or added to the documentation