### PR TITLE
Add operationId to public endpoints

### DIFF
--- a/adoptopenjdk-api-v3-frontend/src/main/kotlin/net/adoptopenjdk/api/v3/routes/AssetsResource.kt
+++ b/adoptopenjdk-api-v3-frontend/src/main/kotlin/net/adoptopenjdk/api/v3/routes/AssetsResource.kt
@@ -64,6 +64,7 @@ constructor(
     @GET
     @Path("/feature_releases/{feature_version}/{release_type}")
     @Operation(
+        operationId = "searchReleases",
         summary = "Returns release information",
         description = "List of information about builds that match the current query"
     )
@@ -172,6 +173,7 @@ constructor(
     @GET
     @Path("/release_name/{vendor}/{release_name}")
     @Operation(
+        operationId = "getReleaseInfo",
         summary = "Returns release information",
         description = "List of releases with the given release name"
     )
@@ -293,6 +295,7 @@ constructor(
     @GET
     @Path("/version/{version}")
     @Operation(
+        operationId = "searchReleasesByVersion",
         summary = "Returns release information about the specified version.",
         description = "List of information about builds that match the current query "
     )
@@ -392,7 +395,7 @@ constructor(
 
     @GET
     @Path("/latest/{feature_version}/{jvm_impl}")
-    @Operation(summary = "Returns list of latest assets for the given feature version and jvm impl")
+    @Operation(summary = "Returns list of latest assets for the given feature version and jvm impl", operationId = "getLatestAssets")
     fun getLatestAssets(
 
         @Parameter(

--- a/adoptopenjdk-api-v3-frontend/src/main/kotlin/net/adoptopenjdk/api/v3/routes/VersionResource.kt
+++ b/adoptopenjdk-api-v3-frontend/src/main/kotlin/net/adoptopenjdk/api/v3/routes/VersionResource.kt
@@ -25,7 +25,11 @@ class VersionResource {
     @GET
     @Path("/{version}")
     @Produces(MediaType.APPLICATION_JSON)
-    @Operation(summary = "Parses a java version string", description = "Parses a java version string and returns that data in a structured format")
+    @Operation(
+        operationId = "parseVersion",
+        summary = "Parses a java version string",
+        description = "Parses a java version string and returns that data in a structured format"
+    )
     @APIResponses(
         value = [
             APIResponse(responseCode = "400", description = "bad input parameter")

--- a/adoptopenjdk-api-v3-frontend/src/main/kotlin/net/adoptopenjdk/api/v3/routes/info/AvailableReleasesResource.kt
+++ b/adoptopenjdk-api-v3-frontend/src/main/kotlin/net/adoptopenjdk/api/v3/routes/info/AvailableReleasesResource.kt
@@ -24,7 +24,7 @@ constructor(
 ) {
     @GET
     @Path("/available_releases/")
-    @Operation(summary = "Returns information about available releases")
+    @Operation(summary = "Returns information about available releases", operationId = "getAvailableReleases")
     fun get(): ReleaseInfo {
         return apiDataStore.getReleaseInfo()
     }

--- a/adoptopenjdk-api-v3-frontend/src/main/kotlin/net/adoptopenjdk/api/v3/routes/info/ReleaseListResource.kt
+++ b/adoptopenjdk-api-v3-frontend/src/main/kotlin/net/adoptopenjdk/api/v3/routes/info/ReleaseListResource.kt
@@ -40,7 +40,7 @@ constructor(
 
     @GET
     @Path("/release_names")
-    @Operation(summary = "Returns a list of all release names")
+    @Operation(summary = "Returns a list of all release names", operationId = "getReleaseNames")
     fun get(
         @Parameter(name = "release_type", description = OpenApiDocs.RELEASE_TYPE, required = false)
         @QueryParam("release_type")
@@ -86,7 +86,7 @@ constructor(
 
     @Path("/release_versions")
     @GET
-    @Operation(summary = "Returns a list of all release versions")
+    @Operation(summary = "Returns a list of all release versions", operationId = "getReleaseVersions")
     fun getVersions(
         @Parameter(name = "release_type", description = OpenApiDocs.RELEASE_TYPE, required = false)
         @QueryParam("release_type")

--- a/adoptopenjdk-api-v3-frontend/src/main/kotlin/net/adoptopenjdk/api/v3/routes/packages/BinaryResource.kt
+++ b/adoptopenjdk-api-v3-frontend/src/main/kotlin/net/adoptopenjdk/api/v3/routes/packages/BinaryResource.kt
@@ -43,7 +43,11 @@ class BinaryResource @Inject constructor(private val packageEndpoint: PackageEnd
     @HEAD
     @Path("/version/{release_name}/{os}/{arch}/{image_type}/{jvm_impl}/{heap_size}/{vendor}")
     @Produces("application/octet-stream")
-    @Operation(summary = "Redirects to the binary that matches your current query", description = "Redirects to the binary that matches your current query")
+    @Operation(
+        operationId = "getBinaryByVersion",
+        summary = "Redirects to the binary that matches your current query",
+        description = "Redirects to the binary that matches your current query"
+    )
     @APIResponses(
         value = [
             APIResponse(responseCode = "307", description = "link to binary that matches your current query"),
@@ -120,7 +124,11 @@ class BinaryResource @Inject constructor(private val packageEndpoint: PackageEnd
     @GET
     @Path("/latest/{feature_version}/{release_type}/{os}/{arch}/{image_type}/{jvm_impl}/{heap_size}/{vendor}")
     @Produces("application/octet-stream")
-    @Operation(summary = "Redirects to the binary that matches your current query", description = "Redirects to the binary that matches your current query")
+    @Operation(
+        operationId = "getBinary",
+        summary = "Redirects to the binary that matches your current query",
+        description = "Redirects to the binary that matches your current query"
+    )
     @APIResponses(
         value = [
             APIResponse(responseCode = "307", description = "link to binary that matches your current query"),

--- a/adoptopenjdk-api-v3-frontend/src/main/kotlin/net/adoptopenjdk/api/v3/routes/packages/BinaryResource.kt
+++ b/adoptopenjdk-api-v3-frontend/src/main/kotlin/net/adoptopenjdk/api/v3/routes/packages/BinaryResource.kt
@@ -28,9 +28,7 @@ import javax.ws.rs.HEAD
 import javax.ws.rs.HeaderParam
 import javax.ws.rs.Path
 import javax.ws.rs.Produces
-import javax.ws.rs.core.Context
 import javax.ws.rs.core.MediaType
-import javax.ws.rs.core.Request
 import javax.ws.rs.core.Response
 
 @Tag(name = "Binary")
@@ -40,7 +38,6 @@ import javax.ws.rs.core.Response
 class BinaryResource @Inject constructor(private val packageEndpoint: PackageEndpoint) {
 
     @GET
-    @HEAD
     @Path("/version/{release_name}/{os}/{arch}/{image_type}/{jvm_impl}/{heap_size}/{vendor}")
     @Produces("application/octet-stream")
     @Operation(
@@ -89,26 +86,68 @@ class BinaryResource @Inject constructor(private val packageEndpoint: PackageEnd
 
         @Parameter(name = "project", description = "Project", required = false)
         @QueryParam("project")
-        project: Project?,
+        project: Project?
+    ): Response {
+        val releases = packageEndpoint.getReleases(release_name, vendor, os, arch, image_type, jvm_impl, heap_size, project)
+        return formResponse(releases)
+    }
 
-        @Context
-        request: Request,
+    @HEAD
+    @Path("/version/{release_name}/{os}/{arch}/{image_type}/{jvm_impl}/{heap_size}/{vendor}")
+    @Produces("application/octet-stream")
+    @Operation(
+        operationId = "getBinaryByVersionHead",
+        summary = "Redirects to the binary that matches your current query",
+        description = "Redirects to the binary that matches your current query"
+    )
+    @APIResponses(
+        value = [
+            APIResponse(responseCode = "307", description = "link to binary that matches your current query"),
+            APIResponse(responseCode = "400", description = "bad input parameter"),
+            APIResponse(responseCode = "404", description = "No matching binary found")
+        ]
+    )
+    fun returnBinaryByVersionHead(
+        @Parameter(name = "os", description = "Operating System", required = true)
+        @PathParam("os")
+        os: OperatingSystem?,
+
+        @Parameter(name = "arch", description = "Architecture", required = true)
+        @PathParam("arch")
+        arch: Architecture?,
+
+        @Parameter(
+            name = "release_name", description = OpenApiDocs.RELASE_NAME, required = true,
+            schema = Schema(defaultValue = "jdk-11.0.6+10", type = SchemaType.STRING)
+        )
+        @PathParam("release_name")
+        release_name: String?,
+
+        @Parameter(name = "image_type", description = "Image Type", required = true)
+        @PathParam("image_type")
+        image_type: ImageType?,
+
+        @Parameter(name = "jvm_impl", description = "JVM Implementation", required = true)
+        @PathParam("jvm_impl")
+        jvm_impl: JvmImpl?,
+
+        @Parameter(name = "heap_size", description = "Heap Size", required = true)
+        @PathParam("heap_size")
+        heap_size: HeapSize?,
+
+        @Parameter(name = "vendor", description = OpenApiDocs.VENDOR, required = true)
+        @PathParam("vendor")
+        vendor: Vendor?,
+
+        @Parameter(name = "project", description = "Project", required = false)
+        @QueryParam("project")
+        project: Project?,
 
         @Parameter(hidden = true, required = false)
         @HeaderParam("User-Agent")
         userAgent: String
     ): Response {
         val releases = packageEndpoint.getReleases(release_name, vendor, os, arch, image_type, jvm_impl, heap_size, project)
-        return when (request.method) {
-            "HEAD" -> versionHead(userAgent, releases)
-            else -> formResponse(releases)
-        }
-    }
-
-    private fun versionHead(
-        userAgent: String,
-        releases: List<Release>
-    ): Response {
         return if (userAgent.contains("Gradle")) {
             return formResponse(releases) { `package` ->
                 Response.status(200)

--- a/adoptopenjdk-api-v3-frontend/src/main/kotlin/net/adoptopenjdk/api/v3/routes/packages/InstallerResource.kt
+++ b/adoptopenjdk-api-v3-frontend/src/main/kotlin/net/adoptopenjdk/api/v3/routes/packages/InstallerResource.kt
@@ -38,7 +38,11 @@ class InstallerResource @Inject constructor(private val packageEndpoint: Package
     @GET
     @Path("/version/{release_name}/{os}/{arch}/{image_type}/{jvm_impl}/{heap_size}/{vendor}")
     @Produces("application/octet-stream")
-    @Operation(summary = "Redirects to the installer that matches your current query", description = "Redirects to the installer that matches your current query")
+    @Operation(
+        operationId = "getInstallerByVersion",
+        summary = "Redirects to the installer that matches your current query",
+        description = "Redirects to the installer that matches your current query"
+    )
     @APIResponses(
         value = [
             APIResponse(responseCode = "307", description = "link to installer that matches your current query"),
@@ -89,7 +93,11 @@ class InstallerResource @Inject constructor(private val packageEndpoint: Package
     @GET
     @Path("/latest/{feature_version}/{release_type}/{os}/{arch}/{image_type}/{jvm_impl}/{heap_size}/{vendor}")
     @Produces("application/octet-stream")
-    @Operation(summary = "Redirects to the installer that matches your current query", description = "Redirects to the installer that matches your current query")
+    @Operation(
+        operationId = "getInstaller",
+        summary = "Redirects to the installer that matches your current query",
+        description = "Redirects to the installer that matches your current query"
+    )
     @APIResponses(
         value = [
             APIResponse(responseCode = "307", description = "link to installer that matches your current query"),


### PR DESCRIPTION
Usually generators like `openapi-generator` create unusable method names, so this PR overrides them by supplying usable names through `operationId` property of openapi specification

# Checklist

- [x] `mvn clean install` build and test completes