### PR TITLE
Log version/date parsing errors

### DIFF
--- a/adoptopenjdk-api-v3-frontend/src/main/kotlin/net/adoptopenjdk/api/v3/routes/VersionResource.kt
+++ b/adoptopenjdk-api-v3-frontend/src/main/kotlin/net/adoptopenjdk/api/v3/routes/VersionResource.kt
@@ -10,6 +10,7 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses
 import org.eclipse.microprofile.openapi.annotations.tags.Tag
 import org.jboss.resteasy.annotations.jaxrs.PathParam
+import org.slf4j.LoggerFactory
 import javax.ws.rs.BadRequestException
 import javax.ws.rs.GET
 import javax.ws.rs.Path
@@ -21,6 +22,11 @@ import javax.ws.rs.core.MediaType
 @Produces(MediaType.APPLICATION_JSON)
 @Timed
 class VersionResource {
+
+    companion object {
+        @JvmStatic
+        private val LOGGER = LoggerFactory.getLogger(this::class.java)
+    }
 
     @GET
     @Path("/{version}")
@@ -39,6 +45,7 @@ class VersionResource {
         try {
             return VersionParser.parse(version, sanityCheck = false, exactMatch = true)
         } catch (e: FailedToParse) {
+            LOGGER.error("Failed to parse version", e)
             throw BadRequestException("Unable to parse version")
         }
     }

--- a/adoptopenjdk-api-v3-frontend/src/main/kotlin/net/adoptopenjdk/api/v3/routes/VersionResource.kt
+++ b/adoptopenjdk-api-v3-frontend/src/main/kotlin/net/adoptopenjdk/api/v3/routes/VersionResource.kt
@@ -45,7 +45,7 @@ class VersionResource {
         try {
             return VersionParser.parse(version, sanityCheck = false, exactMatch = true)
         } catch (e: FailedToParse) {
-            LOGGER.error("Failed to parse version", e)
+            LOGGER.info("Failed to parse version: $version", e)
             throw BadRequestException("Unable to parse version")
         }
     }


### PR DESCRIPTION
Add `info` logging when we have version and date parsing errors. This is likely just the client sending bad data, this logging will help confirm that either way.

See #342 

# Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `mvn clean install` build and test completes