### PR TITLE
Ignore internal PREs to fix openj9 nightly sort order

### DIFF
--- a/adoptopenjdk-api-v3-models/src/main/kotlin/net/adoptopenjdk/api/v3/dataSources/models/Releases.kt
+++ b/adoptopenjdk-api-v3-models/src/main/kotlin/net/adoptopenjdk/api/v3/dataSources/models/Releases.kt
@@ -104,7 +104,18 @@ class Releases {
     }
 
     companion object {
-        val PRE_SORTER = compareBy<VersionData, String?>(nullsLast()) { it.pre }
+
+        // exclude "internal" pre from sorting as this causes incorrect sorting for openj9 nightlies
+        // TODO: remove tactical ignoring "internal" pre fields
+        private val PRE_IGNORE_LIST = listOf("internal")
+
+        val PRE_SORTER = compareBy<VersionData, String?>(nullsLast()) {
+            return@compareBy if (PRE_IGNORE_LIST.contains(it.pre)) {
+                null
+            } else {
+                it.pre
+            }
+        }
 
         // Cant use the default sort as we want to ignore optional
         val VERSION_COMPARATOR = compareBy<VersionData> { it.major }

--- a/adoptopenjdk-api-v3-models/src/test/kotlin/net/adoptopenjdk/api/VersionParserTest.kt
+++ b/adoptopenjdk-api-v3-models/src/test/kotlin/net/adoptopenjdk/api/VersionParserTest.kt
@@ -143,6 +143,23 @@ class VersionParserTest {
         assertEquals("8.0.0", parsed.formSemver())
     }
 
+    //TODO: remove tactical ignoring "internal" pres
+    @Test
+    fun `internal pre is treated as null wrt sorting`() {
+        val unsorted = listOf(
+            VersionData(8, 0, 282, "internal", 0, 7, "202101061709", "1.8.0_282-internal-202101061709-b07"),
+            VersionData(8, 0, 282, "internal", 0, 6, "202012231721", "1.8.0_282-internal-202012231721-b06"),
+            VersionData(8, 0, 282, null, 0, 7, "202101042134", "1.8.0_282-202101042134-b07"),
+            VersionData(8, 0, 282, null, 0, 4, "202012071203", "1.8.0_282-202012071203-b04"),
+        )
+        val sorted = unsorted.sortedWith(Releases.VERSION_COMPARATOR)
+
+        assertEquals(unsorted.get(3), sorted.get(0))
+        assertEquals(unsorted.get(1), sorted.get(1))
+        assertEquals(unsorted.get(0), sorted.get(2))
+        assertEquals(unsorted.get(2), sorted.get(3))
+    }
+
     @Test
     fun `patch versions sort correctly`() {
         val sorted = listOf(


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

# Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] You added tests to cover the change
- [ ] `mvn clean install` build and test completes
- [ ] You changed or added to the documentation