### PR TITLE
Obsolete Master

### DIFF
--- a/adoptopenjdk-api-v3-frontend/src/main/resources/JSON/variants.json
+++ b/adoptopenjdk-api-v3-frontend/src/main/resources/JSON/variants.json
@@ -6,6 +6,7 @@
       "vendor": "adoptopenjdk",
       "version": 8,
       "lts": true,
+      "obsoleteRelease": false,
       "websiteDefault": true
     },
     {
@@ -14,6 +15,7 @@
       "vendor": "adoptopenjdk",
       "version": 8,
       "lts": true,
+      "obsoleteRelease": false,
       "websiteDescription": "Eclipse OpenJ9",
       "websiteDescriptionLink": "https://www.eclipse.org/openj9"
     },
@@ -21,13 +23,15 @@
       "searchableName": "openjdk9-hotspot",
       "jvm": "hotspot",
       "vendor": "adoptopenjdk",
-      "version": 9
+      "version": 9,
+      "obsoleteRelease": true
     },
     {
       "searchableName": "openjdk9-openj9",
       "jvm": "openj9",
       "vendor": "adoptopenjdk",
       "version": 9,
+      "obsoleteRelease": true,
       "websiteDescription": "Eclipse OpenJ9",
       "websiteDescriptionLink": "https://www.eclipse.org/openj9"
     },
@@ -35,13 +39,15 @@
       "searchableName": "openjdk10-hotspot",
       "jvm": "hotspot",
       "vendor": "adoptopenjdk",
-      "version": 10
+      "version": 10,
+      "obsoleteRelease": true
     },
     {
       "searchableName": "openjdk10-openj9",
       "jvm": "openj9",
       "vendor": "adoptopenjdk",
       "version": 10,
+      "obsoleteRelease": true,
       "websiteDescription": "Eclipse OpenJ9",
       "websiteDescriptionLink": "https://www.eclipse.org/openj9"
     },
@@ -50,7 +56,8 @@
       "jvm": "hotspot",
       "vendor": "adoptopenjdk",
       "version": 11,
-      "lts": true
+      "lts": true,
+      "obsoleteRelease": false
     },
     {
       "searchableName": "openjdk11-openj9",
@@ -58,6 +65,7 @@
       "vendor": "adoptopenjdk",
       "version": 11,
       "lts": true,
+      "obsoleteRelease": false,
       "websiteDescription": "Eclipse OpenJ9",
       "websiteDescriptionLink": "https://www.eclipse.org/openj9"
     },
@@ -65,13 +73,15 @@
       "searchableName": "openjdk12-hotspot",
       "jvm": "hotspot",
       "vendor": "adoptopenjdk",
-      "version": 12
+      "version": 12,
+      "obsoleteRelease": true
     },
     {
       "searchableName": "openjdk12-openj9",
       "jvm": "openj9",
       "vendor": "adoptopenjdk",
       "version": 12,
+      "obsoleteRelease": true,
       "websiteDescription": "Eclipse OpenJ9",
       "websiteDescriptionLink": "https://www.eclipse.org/openj9"
     },
@@ -79,13 +89,15 @@
       "searchableName": "openjdk13-hotspot",
       "jvm": "hotspot",
       "vendor": "adoptopenjdk",
-      "version": 13
+      "version": 13,
+      "obsoleteRelease": true
     },
     {
       "searchableName": "openjdk13-openj9",
       "jvm": "openj9",
       "vendor": "adoptopenjdk",
       "version": 13,
+      "obsoleteRelease": true,
       "websiteDescription": "Eclipse OpenJ9",
       "websiteDescriptionLink": "https://www.eclipse.org/openj9"
     },
@@ -93,13 +105,15 @@
       "searchableName": "openjdk14-hotspot",
       "jvm": "hotspot",
       "vendor": "adoptopenjdk",
-      "version": 14
+      "version": 14,
+      "obsoleteRelease": true
     },
     {
       "searchableName": "openjdk14-openj9",
       "jvm": "openj9",
       "vendor": "adoptopenjdk",
       "version": 14,
+      "obsoleteRelease": true,
       "websiteDescription": "Eclipse OpenJ9",
       "websiteDescriptionLink": "https://www.eclipse.org/openj9"
     },
@@ -107,13 +121,15 @@
       "searchableName": "openjdk15-hotspot",
       "jvm": "hotspot",
       "vendor": "adoptopenjdk",
-      "version": 15
+      "version": 15,
+      "obsoleteRelease": true
     },
     {
       "searchableName": "openjdk15-openj9",
       "jvm": "openj9",
       "vendor": "adoptopenjdk",
       "version": 15,
+      "obsoleteRelease": true,
       "websiteDescription": "Eclipse OpenJ9",
       "websiteDescriptionLink": "https://www.eclipse.org/openj9"
     },
@@ -121,13 +137,15 @@
       "searchableName": "openjdk16-hotspot",
       "jvm": "hotspot",
       "vendor": "adoptopenjdk",
-      "version": 16
+      "version": 16,
+      "obsoleteRelease": false
     },
     {
       "searchableName": "openjdk16-openj9",
       "jvm": "openj9",
       "vendor": "adoptopenjdk",
       "version": 16,
+      "obsoleteRelease": false,
       "websiteDescription": "Eclipse OpenJ9",
       "websiteDescriptionLink": "https://www.eclipse.org/openj9"
     }

--- a/adoptopenjdk-api-v3-frontend/src/test/kotlin/net/adoptopenjdk/api/ApiDataStoreStub.kt
+++ b/adoptopenjdk-api-v3-frontend/src/test/kotlin/net/adoptopenjdk/api/ApiDataStoreStub.kt
@@ -44,6 +44,7 @@ open class ApiDataStoreStub : APIDataStore {
     override fun getReleaseInfo(): ReleaseInfo {
         return ReleaseInfo(
             arrayOf(8, 9, 10, 11, 12),
+            arrayOf(9, 10, 12, 13, 14, 15),
             arrayOf(8, 11),
             11,
             12,

--- a/adoptopenjdk-api-v3-frontend/src/test/kotlin/net/adoptopenjdk/api/AvailableReleasesPathTest.kt
+++ b/adoptopenjdk-api-v3-frontend/src/test/kotlin/net/adoptopenjdk/api/AvailableReleasesPathTest.kt
@@ -35,6 +35,13 @@ class AvailableReleasesPathTest : FrontendTest() {
     }
 
     @Test
+    fun obsoleteVersionsIsCorrect() {
+        check { releaseInfo ->
+            releaseInfo.obsolete_releases.contentEquals(arrayOf(9, 10, 12, 13, 14, 15))
+        }
+    }
+
+    @Test
     fun mostRecentLtsIsCorrect() {
         check { releaseInfo ->
             releaseInfo.most_recent_lts == 11

--- a/adoptopenjdk-api-v3-models/src/main/kotlin/net/adoptopenjdk/api/v3/models/ReleaseInfo.kt
+++ b/adoptopenjdk-api-v3-models/src/main/kotlin/net/adoptopenjdk/api/v3/models/ReleaseInfo.kt
@@ -7,6 +7,9 @@ class ReleaseInfo {
     @Schema(example = "[8,9,10,11,12,13,14]", description = "The versions for which adopt have produced a ga release")
     val available_releases: Array<Int>
 
+    @Schema(example = "[9,10,12,13,14,15]", description = "The versions which have reached their end of life")
+    val obsolete_releases: Array<Int>
+
     @Schema(example = "[8,11]", description = "The LTS versions for which adopt have produced a ga release")
     val available_lts_releases: Array<Int>
 
@@ -24,6 +27,7 @@ class ReleaseInfo {
 
     constructor(
         available_releases: Array<Int>,
+        obsolete_releases: Array<Int>,
         available_lts_releases: Array<Int>,
         most_recent_lts: Int,
         most_recent_feature_release: Int,
@@ -31,6 +35,7 @@ class ReleaseInfo {
         tip_version: Int
     ) {
         this.available_releases = available_releases
+        this.obsolete_releases = obsolete_releases
         this.available_lts_releases = available_lts_releases
         this.most_recent_lts = most_recent_lts
         this.most_recent_feature_release = most_recent_feature_release

--- a/adoptopenjdk-api-v3-models/src/main/kotlin/net/adoptopenjdk/api/v3/models/Variant.kt
+++ b/adoptopenjdk-api-v3-models/src/main/kotlin/net/adoptopenjdk/api/v3/models/Variant.kt
@@ -9,6 +9,7 @@ class Variant {
     val vendor: Vendor
     val version: Int
     val lts: Boolean
+    val obsoleteRelease: Boolean
     val websiteDescription: String?
     val websiteDescriptionLink: String?
     val websiteDefault: Boolean?
@@ -28,6 +29,8 @@ class Variant {
         version: Int,
         @JsonProperty("lts")
         lts: Boolean?,
+        @JsonProperty("obsoleteRelease")
+        obsoleteRelease: Boolean,
         @JsonProperty("websiteDescription")
         websiteDescription: String?,
         @JsonProperty("websiteDescriptionLink")
@@ -40,6 +43,7 @@ class Variant {
         this.vendor = vendor
         this.version = version
         this.lts = lts ?: false
+        this.obsoleteRelease = obsoleteRelease
         this.websiteDescription = websiteDescription
         this.websiteDescriptionLink = websiteDescriptionLink
         this.websiteDefault = websiteDefault

--- a/adoptopenjdk-api-v3-persistence/src/main/kotlin/net/adoptopenjdk/api/v3/dataSources/APIDataStoreImpl.kt
+++ b/adoptopenjdk-api-v3-persistence/src/main/kotlin/net/adoptopenjdk/api/v3/dataSources/APIDataStoreImpl.kt
@@ -75,6 +75,7 @@ open class APIDataStoreImpl : APIDataStore {
             // Default for first time when DB is still being populated
             releaseInfo ?: ReleaseInfo(
                 arrayOf(8, 9, 10, 11, 12, 13, 14),
+                arrayOf(9, 10, 12, 13, 14, 15),
                 arrayOf(8, 11),
                 11,
                 14,


### PR DESCRIPTION
* Adds a new attribute (obsolete_releases) to /v3/info/available_releases that lists releases that have reached their end of life.
* Follow up to #314 which was a wontfix due to retiring of staging branch

Closes: #206 
Signed-off-by: Morgan Davies <morgandavies2020@gmail.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

# Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] You added tests to cover the change
- [x] `mvn clean install` build and test completes
- [x] You changed or added to the documentation