### PR TITLE
Add action to publish maven assets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/setup-java@v1
+    - uses: actions/setup-java@v2
       with:
-        java-version: '11.0.7'
+        java-version: '11.0.10'
         java-package: jdk
         architecture: x64
         

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ jobs:
         java-version: '11.0.10'
         java-package: jdk
         architecture: x64
+        distribution: 'adopt'
         
     - uses: actions/setup-node@v1
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v2
         with:
-          java-version: '11.0.7'
+          java-version: '11.0.10'
           java-package: jdk
           architecture: x64
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,39 @@
+on:
+  workflow_dispatch:
+
+name: Publish Assets
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/setup-java@v1
+        with:
+          java-version: '11.0.7'
+          java-package: jdk
+          architecture: x64
+
+      - uses: actions/checkout@v2
+
+      - name: Build app
+        run: ./mvnw --batch-mode clean deploy
+
+      - name: setup git config
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "<>"
+
+      - name: Publish maven assets
+        run: |
+          ls
+          rsync -r ./*/target/mvn-repo ./target/mvn-repo /tmp/
+          git checkout --orphan maven || git checkout maven
+          git reset .
+          rm -r mvn-repo || true
+          cp -r /tmp/mvn-repo ./
+          ls
+          git add mvn-repo
+          git commit -a -m "add artifacts"
+          git push origin maven

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,7 @@ jobs:
           java-version: '11.0.10'
           java-package: jdk
           architecture: x64
+          distribution: 'adopt'
 
       - uses: actions/checkout@v2
 

--- a/adoptopenjdk-api-v3-frontend/pom.xml
+++ b/adoptopenjdk-api-v3-frontend/pom.xml
@@ -152,29 +152,6 @@
         <testSourceDirectory>src/test/kotlin</testSourceDirectory>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>build-helper-maven-plugin</artifactId>
-                <version>3.0.0</version>
-                <executions>
-                    <execution>
-                        <id>attach-artifacts</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>attach-artifact</goal>
-                        </goals>
-                        <configuration>
-                            <artifacts>
-                                <artifact>
-                                    <file>${basedir}/target/${project.artifactId}-${project.version}-runner.jar</file>
-                                    <type>jar</type>
-                                    <classifier>runner</classifier>
-                                </artifact>
-                            </artifacts>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <version>${quarkus.version}</version>
@@ -182,6 +159,8 @@
                     <execution>
                         <goals>
                             <goal>build</goal>
+                            <goal>generate-code</goal>
+                            <goal>generate-code-tests</goal>
                         </goals>
                     </execution>
                 </executions>
@@ -233,18 +212,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>default-jar</id>
-                        <phase>none</phase>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>io.swagger</groupId>
                 <artifactId>swaggerhub-maven-plugin</artifactId>
                 <version>1.0.8</version>
@@ -268,53 +235,4 @@
             </plugin>
         </plugins>
     </build>
-
-    <profiles>
-        <profile>
-            <id>native</id>
-            <activation>
-                <property>
-                    <name>native</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>io.quarkus</groupId>
-                        <artifactId>quarkus-maven-plugin</artifactId>
-                        <version>${quarkus.version}</version>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>native-image</goal>
-                                </goals>
-                                <configuration>
-                                    <enableHttpUrlHandler>true</enableHttpUrlHandler>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>${surefire-plugin.version}</version>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
-                                <configuration>
-                                    <systemProperties>
-                                        <native.image.path>
-                                            ${project.build.directory}/${project.build.finalName}-runner
-                                        </native.image.path>
-                                    </systemProperties>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/adoptopenjdk-api-v3-frontend/src/main/kotlin/net/adoptopenjdk/api/v3/JsonSerialiserConfig.kt
+++ b/adoptopenjdk-api-v3-frontend/src/main/kotlin/net/adoptopenjdk/api/v3/JsonSerialiserConfig.kt
@@ -22,12 +22,12 @@ class JsonSerialiserConfig : ContextResolver<Jsonb> {
                 jsonGenerator.writeNull()
             }
         }
-
     }
 
-    private val jsonb = JsonbBuilder.create(JsonbConfig()
-        .withSerializers(DateTimeSerializer())
-        .withFormatting(true)
+    private val jsonb = JsonbBuilder.create(
+        JsonbConfig()
+            .withSerializers(DateTimeSerializer())
+            .withFormatting(true)
     )
 
     override fun getContext(objectType: Class<*>?): Jsonb {

--- a/adoptopenjdk-api-v3-frontend/src/test/kotlin/net/adoptopenjdk/api/AssetsResourceVersionPathTest.kt
+++ b/adoptopenjdk-api-v3-frontend/src/test/kotlin/net/adoptopenjdk/api/AssetsResourceVersionPathTest.kt
@@ -41,7 +41,7 @@ class AssetsResourceVersionPathTest : AssetsPathTest() {
             RANGE_8_METADATA,
             JAVA11
         )
-            .map { request -> "${getPath()}/${request}?PAGE_SIZE=100" }
+            .map { request -> "${getPath()}/$request?PAGE_SIZE=100" }
             .map { request ->
                 DynamicTest.dynamicTest(request) {
                     RestAssured.given()
@@ -62,7 +62,6 @@ class AssetsResourceVersionPathTest : AssetsPathTest() {
                         })
                         .statusCode(200)
                 }
-
             }
             .stream()
     }

--- a/pom.xml
+++ b/pom.xml
@@ -815,7 +815,9 @@
         </plugins>
     </reporting>
 
-
+    <!--
+        Publishes artifacts to a local directory so that we can check them in and publish them
+    -->
     <distributionManagement>
         <repository>
             <id>internal</id>

--- a/pom.xml
+++ b/pom.xml
@@ -814,4 +814,13 @@
             </plugin>
         </plugins>
     </reporting>
+
+
+    <distributionManagement>
+        <repository>
+            <id>internal</id>
+            <url>file://${project.build.directory}/mvn-repo</url>
+        </repository>
+    </distributionManagement>
+
 </project>


### PR DESCRIPTION
Creates an action that creates a `maven` branch in git, into this branch maven assets get checked in.

Publishing to git a temporary stopgap until we can publish to a real maven repo

# Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] You added tests to cover the change
- [ ] `mvn clean install` build and test completes
- [ ] You changed or added to the documentation