### PR TITLE
Fix version range filter unexpectedly including pre-release versions

### DIFF
--- a/adoptopenjdk-frontend-parent/adoptopenjdk-api-v3-frontend/src/main/kotlin/net/adoptopenjdk/api/v3/filters/VersionRangeFilter.kt
+++ b/adoptopenjdk-frontend-parent/adoptopenjdk-api-v3-frontend/src/main/kotlin/net/adoptopenjdk/api/v3/filters/VersionRangeFilter.kt
@@ -34,11 +34,38 @@ class VersionRangeFilter(range: String?) : Predicate<VersionData> {
                 exactMatcher.compareVersionNumber(version)
             }
             rangeMatcher != null -> {
-                rangeMatcher.containsVersion(version)
+                rangeContainsVersion(rangeMatcher, version)
             }
             else -> {
                 true
             }
         }
+    }
+
+    private fun rangeContainsVersion(rangeMatcher: VersionRange, version: VersionData): Boolean {
+        val noPreVersion = if (version.pre != null) {
+            // Special case where since pre-releases are less than full releases, 17.0.0-beta is less than 17.0.0
+            // this means that if asking for a filter of 16.0.0 < version < 17.0.0, someone would expect this to
+            // return ONLY 16 versions, however since 17.0.0-beta < 17.0.0, 17.0.0-beta will be included. This
+            // although possibly technically correct is not what users would expect. As a solution strip out
+            // pre when performing a range match
+            VersionData(
+                version.major,
+                version.minor,
+                version.security,
+                null,
+                version.adopt_build_number,
+                version.build,
+                version.optional,
+                version.openjdk_version,
+                version.semver,
+                version.patch,
+            )
+        } else {
+            version
+        }
+
+        return rangeMatcher.containsVersion(noPreVersion)
+
     }
 }

--- a/adoptopenjdk-frontend-parent/adoptopenjdk-api-v3-frontend/src/test/kotlin/net/adoptopenjdk/api/VersionRangeFilterTest.kt
+++ b/adoptopenjdk-frontend-parent/adoptopenjdk-api-v3-frontend/src/test/kotlin/net/adoptopenjdk/api/VersionRangeFilterTest.kt
@@ -1,0 +1,26 @@
+package net.adoptopenjdk.api;
+
+import io.quarkus.test.junit.QuarkusTest;
+import net.adoptopenjdk.api.v3.filters.VersionRangeFilter
+import net.adoptopenjdk.api.v3.parser.VersionParser
+import org.junit.jupiter.api.Test;
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@QuarkusTest
+class VersionRangeFilterTest {
+
+    @Test
+    fun versionRangeFilter() {
+        val filter16 = VersionRangeFilter("(16,17)")
+        val filter17 = VersionRangeFilter("(17,18)")
+
+        val first = VersionParser.parse("17-beta+31-202107202346")
+        val second = VersionParser.parse("17+20-202105070000")
+
+        assertFalse(filter16.test(first))
+        assertFalse(filter16.test(second))
+        assertTrue(filter17.test(first))
+        assertTrue(filter17.test(second))
+    }
+}

--- a/adoptopenjdk-models-parent/adoptopenjdk-api-v3-models/src/test/kotlin/api/VersionParserTest.kt
+++ b/adoptopenjdk-models-parent/adoptopenjdk-api-v3-models/src/test/kotlin/api/VersionParserTest.kt
@@ -218,4 +218,17 @@ class VersionParserTest {
         assertEquals(second, sorted.toList()[1])
         assertEquals(third, sorted.toList()[0])
     }
+
+    @Test
+    fun sortOrderIsCorrectWithPres() {
+        val first = VersionParser.parse("17-beta+31-202107202346")
+        val second = VersionParser.parse("17+20-202105070000")
+
+        val sorted = TreeSet<VersionData>()
+        sorted.add(second)
+        sorted.add(first)
+
+        assertEquals(first, sorted.toList()[0])
+        assertEquals(second, sorted.toList()[1])
+    }
 }

--- a/adoptopenjdk-updater-parent/adoptopenjdk-datasources-parent/adoptopenjdk-github-datasource/src/main/kotlin/net/adoptopenjdk/api/v3/dataSources/github/graphql/clients/GraphQLGitHubReleaseRequest.kt
+++ b/adoptopenjdk-updater-parent/adoptopenjdk-datasources-parent/adoptopenjdk-github-datasource/src/main/kotlin/net/adoptopenjdk/api/v3/dataSources/github/graphql/clients/GraphQLGitHubReleaseRequest.kt
@@ -20,7 +20,7 @@ abstract class GraphQLGitHubReleaseRequest(
 
     protected suspend fun getNextPage(release: GHRelease): GHRelease {
         val getMore = getMoreReleasesQuery(release.id)
-        LOGGER.debug("Getting release assets ${release.id}")
+        LOGGER.debug("Getting release assets ${release.id.id}")
         val moreAssets = getAll(
             getMore,
             { asset ->


### PR DESCRIPTION
Since pre-releases are less than full releases, `17.0.0-beta` is less than `17.0.0` this means that if asking for a filter of `16.0.0 < version < 17.0.0`, someone would expect this to return ONLY 16 versions, however since `17.0.0-beta < 17.0.0`, `17.0.0-beta` will be included. This although possibly technically correct is not what users would expect. As a solution strip out pre when performing a range match.

# Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] You added tests to cover the change
- [ ] `mvn clean install` build and test completes
- [ ] You changed or added to the documentation