### PR TITLE
Fix assembly moving to the wrong dir

### DIFF
--- a/.s2i/bin/assemble
+++ b/.s2i/bin/assemble
@@ -13,7 +13,7 @@ if [ -v SWAGGERHUB_APIKEY ]; then
   cd adoptopenjdk-frontend-parent/adoptopenjdk-api-v3-frontend
   unzip target/quarkus-app/quarkus/generated-bytecode.jar META-INF/quarkus-generated-openapi-doc.JSON || true
   ../../mvnw io.swagger:swaggerhub-maven-plugin:upload || true
-  cd ..
+  cd ../..
 fi
 
 mkdir -p /deployments


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

# Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] You added tests to cover the change
- [ ] `mvn clean install` build and test completes
- [ ] You changed or added to the documentation