### PR TITLE
Fix swagger redirect

### DIFF
--- a/adoptopenjdk-frontend-parent/adoptopenjdk-api-v3-frontend/src/main/kotlin/net/adoptopenjdk/api/v3/routes/SwaggerUiRoute.kt
+++ b/adoptopenjdk-frontend-parent/adoptopenjdk-api-v3-frontend/src/main/kotlin/net/adoptopenjdk/api/v3/routes/SwaggerUiRoute.kt
@@ -1,0 +1,26 @@
+package net.adoptopenjdk.api.v3.routes
+
+import org.eclipse.microprofile.openapi.annotations.Operation
+import org.eclipse.microprofile.openapi.annotations.media.Schema
+import java.net.URI
+import javax.ws.rs.GET
+import javax.ws.rs.Path
+import javax.ws.rs.Produces
+import javax.ws.rs.core.MediaType
+import javax.ws.rs.core.Response
+
+@Path("/")
+@Schema(hidden = true)
+@Produces(MediaType.TEXT_PLAIN)
+class SwaggerUiRoute {
+
+    @GET
+    @Schema(hidden = true)
+    @Path("/swagger-ui")
+    @Operation(hidden = true)
+    fun redirect(): Response = Response
+        .status(Response.Status.FOUND)
+        .location(URI("/q/swagger-ui"))
+        .build()
+
+}

--- a/adoptopenjdk-models-parent/adoptopenjdk-api-v3-adopt-specific-models/src/main/kotlin/net/adoptopenjdk/api/v3/models/VendorSchemaRef.kt
+++ b/adoptopenjdk-models-parent/adoptopenjdk-api-v3-adopt-specific-models/src/main/kotlin/net/adoptopenjdk/api/v3/models/VendorSchemaRef.kt
@@ -10,7 +10,7 @@ object VendorSchemaRef {
     }
 
     fun applyVendorMapping(vendor: String): String {
-        return if (AdoptVendor.VENDOR_MAPPING.containsKey(vendor.lowercase())) {
+        return if (AdoptVendor.VENDOR_MAPPING.containsKey(vendor.toLowerCase())) {
             AdoptVendor.VENDOR_MAPPING[vendor]!!
         } else {
             vendor


### PR DESCRIPTION
For some reason `/swagger-ui` is not redirecting to `/q/swagger-ui` explicitly add the redirect

# Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] You added tests to cover the change
- [ ] `mvn clean install` build and test completes
- [ ] You changed or added to the documentation